### PR TITLE
검색 결과 개수 컴포넌트 구현

### DIFF
--- a/src/common/components/SearchResultText/SearchResultText.stories.tsx
+++ b/src/common/components/SearchResultText/SearchResultText.stories.tsx
@@ -1,0 +1,27 @@
+import { ComponentMeta, ComponentStory } from '@storybook/react';
+import SearchResultText from './SearchResultText';
+
+export default {
+  title: 'common/components/SearchResultText',
+  component: SearchResultText,
+  args: {
+    keyword: '검색어',
+    resultCount: 0,
+  },
+  argTypes: {
+    resultCount: {
+      control: { type: 'range', mix: 0, max: 100, step: 1 },
+    },
+  },
+  parameters: {
+    design: {
+      url: 'https://www.figma.com/file/y5dq4m439YJKRTrKw5ZsZV/33-1%2F3?node-id=684%3A1153&t=IZlZBzSRbsy5uc2f-4',
+    },
+  },
+} as ComponentMeta<typeof SearchResultText>;
+
+const Template: ComponentStory<typeof SearchResultText> = (args) => (
+  <SearchResultText {...args} />
+);
+
+export const Exapmle = Template.bind({});

--- a/src/common/components/SearchResultText/SearchResultText.tsx
+++ b/src/common/components/SearchResultText/SearchResultText.tsx
@@ -1,0 +1,40 @@
+import styled, { css } from 'styled-components';
+
+export interface SearchResultTextProps {
+  keyword: string;
+  resultCount: number;
+}
+
+function SearchResultText({ keyword, resultCount }: SearchResultTextProps) {
+  return (
+    <SearchResultTextWrapper>
+      <KeyWord>{`"${keyword}"`}</KeyWord>
+      <ResultInfo>{`검색 결과 ${resultCount}건`}</ResultInfo>
+    </SearchResultTextWrapper>
+  );
+}
+
+SearchResultText.defaultProps = { keyword: '검색어', resultCount: 0 };
+
+const fontStyle = css`
+  font-weight: 700;
+  font-size: var(--text-md);
+`;
+
+const SearchResultTextWrapper = styled.div`
+  display: flex;
+  flex-flow: row nowrap;
+  gap: var(--space-xs);
+`;
+
+const KeyWord = styled.span`
+  ${fontStyle};
+  color: var(--purple-900);
+`;
+
+const ResultInfo = styled.span`
+  ${fontStyle};
+  color: var(--black);
+`;
+
+export default SearchResultText;


### PR DESCRIPTION
## PR Type
- [x] FEAT: 새로운 기능 구현
- [ ] FIX: 버그 수정
- [ ] DOCS: 문서 추가 및 수정
- [ ] STYLE: 포맷팅 변경
- [ ] REFACTOR: 코드 리팩토링
- [x] TEST: 테스트 관련
- [ ] DEPLOY: 배포 관련
- [ ] CHORE: 빌드, 환경 설정 등 기타 작업

## Abstracts
* 검색 결과 페이지의 검색 결과 개수를 표시하는 컴포넌트를 구현했습니다.

## Description
### 검색 결과 개수 컴포넌트
**컴포넌트 구조**
```
<SearchResultText>
  <SearchResultTextWrapper>
    <KeyWord></KeyWord>
    <ResultInfo></ResultInfo>
  </SearchResultTextWrapper>
</SearchResultText>
```

**전달하는 props**
* SearchResultText 컴포넌트
  * `keyword: string` : 입력한 검색어를 표시하기 위한 prop
  * `resultCount: number` : 검색 결과 개수를 표시하기 위한 prop

**작업 내용**
* 검색 결과 개수를 표시하는 컴포넌트의 구현을 완료했습니다.
* 각 컴포넌트의 스토리 생성을 완료했습니다.
  * 생성한 스토리 목록
  ![image](https://user-images.githubusercontent.com/101828759/206230060-1d27c401-52c6-4e68-9cd0-587d472c4e24.png)
  * Story Book 예제
  ![image](https://user-images.githubusercontent.com/101828759/206230114-7384d766-a334-47b3-a877-63b96c267038.png)

---
Close #27 
