### PR TITLE
로그인폼 버튼 활성화 버그 해결 및 모달 컴포넌트 구현

### DIFF
--- a/src/common/components/Dialog/Dialog.stories.tsx
+++ b/src/common/components/Dialog/Dialog.stories.tsx
@@ -1,0 +1,68 @@
+import { ComponentStory, ComponentMeta } from '@storybook/react';
+import Dialog from './Dialog';
+
+import { TextInput } from '@/pages/MyCollection/components';
+
+export default {
+  title: 'common/components/Dialog',
+  component: Dialog,
+} as ComponentMeta<typeof Dialog>;
+
+const Template: ComponentStory<typeof Dialog> = (args) => <Dialog {...args} />;
+
+export const AddItemDialog = Template.bind({});
+AddItemDialog.args = {
+  isOpen: true,
+  width: 480,
+  height: 480,
+  title: 'Add Items',
+  children: <div>Pull 받아서 컴포넌트 채워넣을 예정</div>,
+  confirm: () => console.log('아이템 추가'),
+};
+
+export const CreateCollectionDialog = Template.bind({});
+CreateCollectionDialog.args = {
+  isOpen: true,
+  width: 480,
+  height: 300,
+  title: 'Create Collection',
+  children: (
+    <TextInput
+      errorMsg="최소 두 글자 이상 입력해주세요."
+      height={36}
+      label="Collection Name"
+      placeholder="생성할 콜렉션의 이름을 입력해주세요."
+      required
+      validationTester={/^.{2,}$/}
+      width={416}
+    />
+  ),
+  confirm: () => console.log('콜렉션 생성'),
+};
+
+export const DeleteCollectionDialog = Template.bind({});
+DeleteCollectionDialog.args = {
+  isOpen: true,
+  width: 480,
+  height: 200,
+  children: '콜렉션을 삭제하시겠습니까?',
+  confirm: () => console.log('콜렉션 삭제'),
+};
+
+export const DeleteItemDialog = Template.bind({});
+DeleteItemDialog.args = {
+  isOpen: true,
+  width: 480,
+  height: 200,
+  children: '아이템을 삭제하시겠습니까?',
+  confirm: () => console.log('아이템 삭제'),
+};
+
+export const LongText = Template.bind({});
+LongText.args = {
+  isOpen: true,
+  width: 480,
+  height: 200,
+  children:
+    'Lorem, ipsum dolor sit amet consectetur adipisicing elit. Doloremque minima voluptate vero, nam repellat ipsam reiciendis nemo officiis quis voluptates, commodi animi dolores rem soluta praesentium molestias molestiae ad voluptas?',
+};

--- a/src/common/components/Dialog/Dialog.stories.tsx
+++ b/src/common/components/Dialog/Dialog.stories.tsx
@@ -65,4 +65,5 @@ LongText.args = {
   height: 200,
   children:
     'Lorem, ipsum dolor sit amet consectetur adipisicing elit. Doloremque minima voluptate vero, nam repellat ipsam reiciendis nemo officiis quis voluptates, commodi animi dolores rem soluta praesentium molestias molestiae ad voluptas?',
+  confirm: () => console.log('확인'),
 };

--- a/src/common/components/Dialog/Dialog.tsx
+++ b/src/common/components/Dialog/Dialog.tsx
@@ -1,0 +1,116 @@
+import styled from 'styled-components';
+import { createPortal } from 'react-dom';
+import SqaureButton from '../SquareButton/SquareButton';
+
+const DialogBackground = styled.div`
+  position: fixed;
+  z-index: 1000;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.7);
+  backdrop-filter: blur(8px);
+`;
+
+const DialogContainer = styled.div`
+  display: flex;
+  flex-direction: column;
+  position: fixed;
+  z-index: 1000;
+  top: 50%;
+  left: 50%;
+  translate: -50% -50%;
+  border-radius: 16px;
+  background: var(--white);
+  box-shadow: var(--shadow-Modal);
+`;
+
+const DialogTitle = styled.h2`
+  padding: 24px;
+  font-size: 32px;
+  font-weight: 700;
+  border-bottom: 1px solid var(--gray-100);
+`;
+
+const DialogNodeContent = styled.div`
+  flex-grow: 1;
+  margin: 24px 24px 0 24px;
+  overflow-y: scroll;
+`;
+
+const DialogStringContent = styled.span`
+  flex-grow: 1;
+  margin: 24px 24px 0 24px;
+  overflow-y: scroll;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  font-size: 28px;
+`;
+
+const DialogButtons = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 20px;
+  padding: 24px;
+`;
+
+const closeDialog = () => {
+  console.log('closeDialog');
+};
+
+export interface DialogProps {
+  isOpen: boolean;
+  width: number;
+  height: number;
+  title?: string;
+  children: React.ReactNode;
+  confirm: () => void;
+}
+
+const Dialog = ({
+  isOpen,
+  width,
+  height,
+  title,
+  children,
+  confirm,
+  ...props
+}: DialogProps) =>
+  createPortal(
+    <>
+      {isOpen && (
+        <DialogBackground onClick={closeDialog}>
+          <DialogContainer
+            style={{ width, height }}
+            onClick={(e) => e.stopPropagation()}
+          >
+            {title && <DialogTitle>{title}</DialogTitle>}
+            {typeof children === 'string' ? (
+              <DialogStringContent>{children}</DialogStringContent>
+            ) : (
+              <DialogNodeContent>{children}</DialogNodeContent>
+            )}
+            <DialogButtons>
+              <SqaureButton fontSize={18} size={'large'} onClick={confirm}>
+                확인
+              </SqaureButton>
+              <SqaureButton
+                fontSize={18}
+                size={'large'}
+                isFilled={false}
+                onClick={closeDialog}
+              >
+                취소
+              </SqaureButton>
+            </DialogButtons>
+          </DialogContainer>
+        </DialogBackground>
+      )}
+    </>,
+    document.getElementById('root') as Element
+  );
+
+export default Dialog;

--- a/src/common/components/SignInAndUpForm/SignInAndUpForm.tsx
+++ b/src/common/components/SignInAndUpForm/SignInAndUpForm.tsx
@@ -87,14 +87,20 @@ const SignInAndUpForm = ({ option, ...props }: SignInAndUpFormProps) => {
         size="small"
         isFilled={true}
         disabled={
-          formState.id === '' ||
-          formState.nickname === '' ||
-          formState.pwd === '' ||
-          formState.pwdCheck === '' ||
-          !IS_VALID.id ||
-          !IS_VALID.nickname ||
-          !IS_VALID.pwd ||
-          !IS_VALID.pwdCheck
+          (option === 'signin' &&
+            (formState.id === '' ||
+              formState.pwd === '' ||
+              !IS_VALID.id ||
+              !IS_VALID.pwd)) ||
+          (option === 'signup' &&
+            (formState.id === '' ||
+              formState.nickname === '' ||
+              formState.pwd === '' ||
+              formState.pwdCheck === '' ||
+              !IS_VALID.id ||
+              !IS_VALID.nickname ||
+              !IS_VALID.pwd ||
+              !IS_VALID.pwdCheck))
         }
       >
         {option === 'signin' ? 'Sign In' : 'Sign Up'}


### PR DESCRIPTION
## PR Type
- [x] FEAT: 새로운 기능 구현
- [x] FIX: 버그 수정
- [ ] DOCS: 문서 추가 및 수정
- [ ] STYLE: 포맷팅 변경
- [ ] REFACTOR: 코드 리팩토링
- [x] TEST: 테스트 관련
- [ ] DEPLOY: 배포 관련
- [ ] CHORE: 빌드, 환경 설정 등 기타 작업

## Abstracts
* 로그인 폼에서 버튼이 활성화되지 않는 문제를 해결하였습니다.
* 모달 컴포넌트를 구현하였습니다.

## Description
- 모달 컴포넌트 구현
  - props
    - `isOpen: boolean`: 모달이 열려있는지 여부
    - `width: number`: 모달의 가로길이(px)
    - `hight: number`: 모달의 세로길이(px)
    - `title?: string`: 모달의 제목
    - `children: React.ReactNode`: 모달의 콘텐츠 → 개발자의 편의를 위해 type이 node와 string일 경우 다르게 렌더링
    - `confirm: () => void`: 모달 내부 확인 버튼을 눌렀을 때 호출될 함수
  - 작업 내용
    - isOpen prop으로 모달이 열려있는지 여부를 받아 모달 렌더링
    - 뷰포트를 채우는 모달 배경을 구현하고 배경을 클릭했을 시 closeDialog 함수 호출
    - width, height props로 모달 크기 지정
    - title prop으로 모달 title을 받아 렌더링
    - children prop으로 모달 컨텐츠를 받아 children이 string타입일 경우와 node 타입일 경우 다르게 렌더링
    - 모달 하단의 고정된 위치에 확인, 취소 버튼 배치
    - 확인 버튼을 클릭했을 시 props로 내려받은 confirm 함수 호출
    - 취소 버튼을 클릭했을 시 closeDialog 함수 호출
    - 디자인 시안 기반 스타일 적용
    - StoryBook으로 테스트

<img width="459" alt="스크린샷 2022-12-09 오후 6 37 27" src="https://user-images.githubusercontent.com/70943835/206676536-3cd6da9f-12ff-43fa-8543-8f21f6668f0f.png">

<img width="459" alt="스크린샷 2022-12-09 오후 6 36 23" src="https://user-images.githubusercontent.com/70943835/206676555-97f90a1b-203b-41ef-a11b-39f45ecbca48.png">

<img width="459" alt="스크린샷 2022-12-09 오후 6 36 31" src="https://user-images.githubusercontent.com/70943835/206676570-4eae1b86-c372-4dd4-abc5-f7930460d873.png">

<img width="459" alt="스크린샷 2022-12-09 오후 6 36 35" src="https://user-images.githubusercontent.com/70943835/206676591-7b6a27be-d3a8-4c49-b9e1-80e4242179c0.png">

![Dialog](https://user-images.githubusercontent.com/70943835/206676688-71e215d5-3a53-48f9-8ece-e16214d01313.gif)



## Discussion
* 이후 접근성 고려 필요
* LongText의 경우 스크롤 에러 해결 필요

---
Close #57 
