### PR TITLE
타입 에러 수정 & 전체 검색 상세 페이지 구현

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -15,7 +15,7 @@ function App() {
       <Route path="/signin" element={<Signin />}></Route>
       <Route path="/signup" element={<Signup />}></Route>
       <Route path="/searchresult" element={<SearchResult />}></Route>
-      <Route path="/item/:isbn" element={<Item />}></Route>
+      <Route path="/item/:id" element={<Item />}></Route>
       <Route path="/mycollections/:userid" element={<MyCollections />}></Route>
       <Route
         path="/mycollection/:userid/:collectionid"

--- a/src/common/components/AlbumInfo/AlbumInfo.stories.tsx
+++ b/src/common/components/AlbumInfo/AlbumInfo.stories.tsx
@@ -1,11 +1,10 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import {
-  mockTitleInfo_default,
-  mockTitleInfo_ellipsis,
-  mockDetailInfo_default,
-  mockDetailInfo_ellipsis,
+  mockSearchResult_default,
+  mockSearchResult_ellipsis,
 } from '@/utils/mocks/mockInfo';
 import AlbumInfo from './AlbumInfo';
+import { ProcessedResult } from '@/types/data';
 
 export default {
   title: 'common/components/AlbumInfo',
@@ -42,30 +41,26 @@ export const AllDefault = Template.bind({});
 AllDefault.args = {
   page: 'all',
   view: 'block',
-  titleInfo: mockTitleInfo_default,
-  detailInfo: mockDetailInfo_default,
+  searchResult: mockSearchResult_default as ProcessedResult,
 };
 
 export const AllEllpsis = Template.bind({});
 AllEllpsis.args = {
   page: 'all',
   view: 'block',
-  titleInfo: mockTitleInfo_ellipsis,
-  detailInfo: mockDetailInfo_ellipsis,
+  searchResult: mockSearchResult_ellipsis as ProcessedResult,
 };
 
 export const CollectionDefault = Template.bind({});
 CollectionDefault.args = {
   page: 'collection',
   view: 'block',
-  titleInfo: mockTitleInfo_default,
-  detailInfo: mockDetailInfo_default,
+  searchResult: mockSearchResult_default as ProcessedResult,
 };
 
 export const CollectionEllpsis = Template.bind({});
 CollectionEllpsis.args = {
   page: 'collection',
   view: 'block',
-  titleInfo: mockTitleInfo_ellipsis,
-  detailInfo: mockDetailInfo_ellipsis,
+  searchResult: mockSearchResult_ellipsis as ProcessedResult,
 };

--- a/src/common/components/AlbumInfo/AlbumInfo.tsx
+++ b/src/common/components/AlbumInfo/AlbumInfo.tsx
@@ -1,36 +1,33 @@
-import TitleInfo from '../TitleInfo/TitleInfo';
-import DetailInfo, { DetailInfoProps } from '../DetailInfo/DetailInfo';
-import IconButton from '../IconButton/IconButton';
+import uuid from 'react-uuid';
+import { TitleInfo, IconButton } from '@/common/components';
+import DetailInfo from '../DetailInfo/DetailInfo';
 import styled, { css } from 'styled-components';
+import { ProcessedResult, ProcessedTracklist } from '@/types/data';
 
 export interface ResultViewProps {
   view: 'block' | 'list' | 'detail';
 }
-
-export interface TitleInfoProps {
-  title: string;
-  artist: string;
-}
-
 export interface AlbumInfoProps extends ResultViewProps {
-  titleInfo: TitleInfoProps;
-  detailInfo: DetailInfoProps[];
+  searchResult: ProcessedResult;
+  tracklist?: ProcessedTracklist;
   page: 'all' | 'collection';
 }
 
 function AlbumInfo({
-  titleInfo,
-  detailInfo,
+  searchResult,
+  tracklist,
   page,
   view,
   ...props
 }: AlbumInfoProps) {
   const buttonSize = view === 'block' ? 16 : 32;
   const buttonType = page === 'all' ? 'plus' : 'minus';
+  const { titleInfo, detailInfo } = searchResult;
 
   const listInfo = detailInfo.filter(
     ({ infoName }) => infoName === 'Released' || infoName === 'Genre'
   );
+  const newDetailInfo = tracklist ? [...detailInfo, tracklist] : detailInfo;
 
   return (
     <>
@@ -44,7 +41,7 @@ function AlbumInfo({
           <ListInfoWrapper>
             {listInfo.map(({ infoName, infoContent, isValid }) => (
               <DetailInfo
-                key={infoName}
+                key={uuid()}
                 infoName={infoName}
                 infoContent={infoContent}
                 isValid={isValid}
@@ -52,7 +49,7 @@ function AlbumInfo({
             ))}
           </ListInfoWrapper>
         )}
-        <S_IconButton
+        <StyledIconButton
           width={buttonSize}
           height={buttonSize}
           iconType={buttonType}
@@ -61,9 +58,9 @@ function AlbumInfo({
       </AlbumInfoWrapper>
       {view === 'detail' && (
         <DetailInfoWrapper>
-          {detailInfo.map(({ infoName, infoContent, isValid }) => (
+          {newDetailInfo.map(({ infoName, infoContent, isValid }) => (
             <DetailInfo
-              key={infoName}
+              key={uuid()}
               infoName={infoName}
               infoContent={infoContent}
               isValid={isValid}
@@ -131,7 +128,7 @@ const DetailInfoWrapper = styled.dl`
   padding: 0px var(--space-xs);
 `;
 
-const S_IconButton = styled(IconButton)<ResultViewProps>`
+const StyledIconButton = styled(IconButton)<ResultViewProps>`
   position: absolute;
   ${({ view }) => BUTTON_STYLE[view]};
 `;

--- a/src/common/components/DetailInfo/DetailInfo.stories.tsx
+++ b/src/common/components/DetailInfo/DetailInfo.stories.tsx
@@ -14,17 +14,6 @@ export default {
   },
 } as ComponentMeta<typeof DetailInfo>;
 
-const mockTrackList = [
-  { position: 'A1', title: '나의 옛날 이야기', duration: '3:33' },
-  { position: 'A2', title: '꽃', duration: '2:59' },
-  { position: 'A3', title: '삐에로는 우릴 보고 웃지', duration: '3:53' },
-  { position: 'A4', title: '사랑이 지나가면', duration: '4:00' },
-  { position: 'B1', title: '너의 의미', duration: '3:15' },
-  { position: 'B2', title: '여름밤의 꿈', duration: '3:56' },
-  { position: 'B3', title: '꿍따리 샤바라', duration: '3:48' },
-  { position: 'B4', title: '어허야 둥기둥기', duration: '2:34' },
-];
-
 const Template: ComponentStory<typeof DetailInfo> = (args) => (
   <DetailInfo {...args} />
 );
@@ -57,10 +46,4 @@ export const Label = Template.bind({});
 Label.args = {
   infoName: 'Label',
   infoContent: ['Loen Entertainment'],
-};
-
-export const Tracklist = Template.bind({});
-Tracklist.args = {
-  infoName: 'Tracklist',
-  infoContent: mockTrackList,
 };

--- a/src/common/components/DetailInfo/DetailInfo.tsx
+++ b/src/common/components/DetailInfo/DetailInfo.tsx
@@ -1,34 +1,29 @@
+import uuid from 'react-uuid';
+import { Fragment } from 'react';
 import styled, { css } from 'styled-components';
+import { RawTracklist } from '@/types/data';
 
-const ARRAY_INFO = ['Genre', 'Style', 'Label'];
-
-export interface TracklistType {
-  position: string;
-  title: string;
-  duration: string;
-}
-
-export interface commonProps {
+export interface InfoNameProps {
   infoName: 'Country' | 'Genre' | 'Label' | 'Style' | 'Released' | 'Tracklist';
-  infoContent: string | Array<string> | Array<TracklistType>;
 }
 
-export interface DetailInfoProps extends commonProps {
+export interface InfoContentProps {
+  infoContent: string | string[] | RawTracklist[];
+}
+
+export interface DetailInfoProps extends InfoNameProps, InfoContentProps {
   isValid: boolean;
 }
 
-const checkTracklist = ({ infoName, infoContent }: commonProps) =>
-  Array.isArray(infoContent) && !ARRAY_INFO.includes(infoName);
+const checkTracklist = ({ infoName }: InfoNameProps) =>
+  infoName === 'Tracklist';
 
 function DetailInfo({ infoName, infoContent, isValid }: DetailInfoProps) {
   if (!isValid) return null;
 
-  const isTracklist = checkTracklist({ infoName, infoContent });
-
+  const isTracklist = checkTracklist({ infoName });
   const infoString =
-    typeof infoContent === 'string' && !isTracklist
-      ? infoContent
-      : (infoContent as Array<string>).join(', ');
+    typeof infoContent === 'string' ? infoContent : infoContent.join(', ');
 
   return (
     <>
@@ -36,12 +31,12 @@ function DetailInfo({ infoName, infoContent, isValid }: DetailInfoProps) {
       {isTracklist ? (
         <InfoContent>
           <Tracklist>
-            {(infoContent as Array<TracklistType>).map((track) => (
-              <>
+            {(infoContent as RawTracklist[]).map((track) => (
+              <Fragment key={uuid()}>
                 <span>{track.position}</span>
                 <span>{track.title}</span>
                 <span>{track.duration}</span>
-              </>
+              </Fragment>
             ))}
           </Tracklist>
         </InfoContent>

--- a/src/common/components/LPCover/LPCover.stories.tsx
+++ b/src/common/components/LPCover/LPCover.stories.tsx
@@ -1,6 +1,8 @@
 // import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
+import { mockSearchResult_default } from '@/utils/mocks/mockInfo';
 import LPCover from './LPCover';
+import { ProcessedResult } from '@/types/data';
 
 export default {
   title: 'common/components/LPCover',
@@ -18,34 +20,31 @@ const Template: ComponentStory<typeof LPCover> = (args) => (
 
 export const SmallWithHoverEvnet = Template.bind({});
 SmallWithHoverEvnet.args = {
-  imgURL:
-    'https://i.discogs.com/jgaM3Iwz2t05Whh7VHfdtqYtIseHo3mRqk1PQNIUsF0/rs:fit/g:sm/q:90/h:398/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYwMDg0/MDEtMTQwODY5NzMw/MS0zMzE2LmpwZWc.jpeg',
-  title: '꽃갈피',
+  searchResult: mockSearchResult_default as ProcessedResult,
   size: 'small',
   hoverInteraction: true,
 };
 
 export const BigWithoutHoverEvent = Template.bind({});
 BigWithoutHoverEvent.args = {
-  imgURL:
-    'https://i.discogs.com/jgaM3Iwz2t05Whh7VHfdtqYtIseHo3mRqk1PQNIUsF0/rs:fit/g:sm/q:90/h:398/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYwMDg0/MDEtMTQwODY5NzMw/MS0zMzE2LmpwZWc.jpeg',
-  title: '꽃갈피',
+  searchResult: mockSearchResult_default as ProcessedResult,
   size: 'large',
   hoverInteraction: false,
 };
 
 export const ImgURLIsEmptyString = Template.bind({});
 ImgURLIsEmptyString.args = {
-  imgURL: '',
-  title: '꽃갈피',
+  searchResult: { ...mockSearchResult_default, imgURL: '' } as ProcessedResult,
   size: 'small',
   hoverInteraction: true,
 };
 
 export const ImgURLIsInvalid = Template.bind({});
 ImgURLIsInvalid.args = {
-  imgURL: 'asdfasdf',
-  title: '꽃갈피',
+  searchResult: {
+    ...mockSearchResult_default,
+    imgURL: 'asdfasdf',
+  } as ProcessedResult,
   size: 'small',
   hoverInteraction: true,
 };

--- a/src/common/components/LPCover/LPCover.tsx
+++ b/src/common/components/LPCover/LPCover.tsx
@@ -1,11 +1,13 @@
+import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import { ProcessedResult } from '@/types/data';
 
 const HEIGHT_PX = {
   small: 150,
   large: 394,
 };
 
-const Wrapper = styled.div<{ heightNum: number }>`
+const Wrapper = styled(Link)<{ heightNum: number }>`
   position: relative;
 
   &:hover .vinyl {
@@ -46,10 +48,7 @@ const Vinyl = styled.img`
 `;
 
 export interface LPCoverProps {
-  // 음반 커버 이미지 경로
-  imgURL: string;
-  // 음반 커버 이미지 경로가 올바르지 않을 때 대체 음반 커버 이미지와 함께 표시할 음반 제목
-  title: string;
+  searchResult: ProcessedResult;
   // 표시할 음반 커버 크기
   size: 'small' | 'large';
   // 마우스 호버시 LP판 나오는 애니메이션 작동 여부
@@ -58,16 +57,18 @@ export interface LPCoverProps {
 }
 
 const LPCover = ({
-  imgURL,
-  title,
+  searchResult,
   size,
   hoverInteraction,
   ...props
 }: LPCoverProps) => {
   const heightNum = HEIGHT_PX[size];
+  const { id, titleInfo, imgURL } = searchResult;
 
   return (
     <Wrapper
+      to={`/item/${id}`}
+      state={searchResult}
       heightNum={heightNum}
       style={{ width: `${heightNum}px`, height: `${heightNum}px` }}
       {...props}
@@ -75,7 +76,7 @@ const LPCover = ({
       <Cover
         src={imgURL}
         alt=""
-        data-title={title}
+        data-title={titleInfo.title}
         heightNum={heightNum}
         width={`${heightNum}`}
         height={`${heightNum}`}

--- a/src/common/components/VinylItem/VinylItem.stories.tsx
+++ b/src/common/components/VinylItem/VinylItem.stories.tsx
@@ -1,18 +1,12 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
-import {
-  mockTitleInfo_default,
-  mockDetailInfo_default,
-  mockImgURL,
-} from '@/utils/mocks/mockInfo';
+import { mockSearchResult_default } from '@/utils/mocks/mockInfo';
 import VinylItem from './VinylItem';
 
 export default {
   title: 'common/components/VinylItem',
   component: VinylItem,
   args: {
-    titleInfo: mockTitleInfo_default,
-    detailInfo: mockDetailInfo_default,
-    imgURL: mockImgURL,
+    searchResult: mockSearchResult_default,
   },
   argTypes: {
     page: {

--- a/src/common/components/VinylItem/VinylItem.tsx
+++ b/src/common/components/VinylItem/VinylItem.tsx
@@ -1,39 +1,27 @@
 import LPCover from '../LPCover/LPCover';
-import AlbumInfo, {
-  ResultViewProps,
-  AlbumInfoProps,
-} from '../AlbumInfo/AlbumInfo';
+import { AlbumInfo } from '@/common/components';
+import { ProcessedResult } from '@/types/data';
+import { ResultViewProps } from '../AlbumInfo/AlbumInfo';
 import styled, { css } from 'styled-components';
 
-export interface VinylItemProps extends AlbumInfoProps, ResultViewProps {
-  imgURL: string;
+export interface VinylItemProps {
+  searchResult: ProcessedResult;
+  page: 'all' | 'collection';
+  view: 'block' | 'list' | 'detail';
 }
 
-function VinylItem({
-  titleInfo,
-  detailInfo,
-  imgURL,
-  page,
-  view,
-  ...props
-}: VinylItemProps) {
+function VinylItem({ searchResult, page, view, ...props }: VinylItemProps) {
   const vinylSize = view === 'detail' ? 'large' : 'small';
   const isHover = view !== 'detail';
 
   return (
     <VinylItemWrapper view={view} {...props}>
       <LPCover
-        imgURL={imgURL}
-        title={titleInfo.title}
+        searchResult={searchResult}
         size={vinylSize}
         hoverInteraction={isHover}
       />
-      <AlbumInfo
-        titleInfo={titleInfo}
-        detailInfo={detailInfo}
-        page={page}
-        view={view}
-      />
+      <AlbumInfo searchResult={searchResult} page={page} view={view} />
     </VinylItemWrapper>
   );
 }

--- a/src/common/components/VinylItems/VinylItems.stories.tsx
+++ b/src/common/components/VinylItems/VinylItems.stories.tsx
@@ -1,12 +1,12 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
-import { mockSearchResult } from '@/utils/mocks/mockInfo';
+import { mockSearchResults } from '@/utils/mocks/mockInfo';
 import VinylItems from './VinylItems';
 
 export default {
   title: 'common/components/VinylItems',
   component: VinylItems,
   args: {
-    searchResult: mockSearchResult,
+    searchResults: mockSearchResults,
   },
 } as ComponentMeta<typeof VinylItems>;
 

--- a/src/common/components/VinylItems/VinylItems.tsx
+++ b/src/common/components/VinylItems/VinylItems.tsx
@@ -1,31 +1,20 @@
-import uuid from 'react-uuid';
 import VinylItem from '../VinylItem/VinylItem';
-import { TitleInfoProps } from '../TitleInfo/TitleInfo';
-import { DetailInfoProps } from '../DetailInfo/DetailInfo';
 import { ResultViewProps } from '../AlbumInfo/AlbumInfo';
-import { ProcessResult } from '@/types/data';
+import { ProcessedResult } from '@/types/data';
 import styled, { css } from 'styled-components';
 
-export interface VinylItemProps {
-  titleInfo: TitleInfoProps;
-  detailInfo: DetailInfoProps[];
-  imgURL: string;
-}
-
 export interface VinylItemsProps extends ResultViewProps {
-  searchResult: ProcessResult[];
+  searchResult: ProcessedResult[];
   page: 'all' | 'collection';
 }
 
 function VinylItems({ searchResult, page, view, ...props }: VinylItemsProps) {
   return (
     <VinylItemsWrapper view={view} {...props}>
-      {searchResult.map(({ titleInfo, detailInfo, imgURL }) => (
+      {searchResult.map((result) => (
         <VinylItem
-          key={uuid()}
-          titleInfo={titleInfo}
-          detailInfo={detailInfo}
-          imgURL={imgURL}
+          key={result.id}
+          searchResult={result}
           page={page}
           view={view}
         />

--- a/src/pages/Item/index.tsx
+++ b/src/pages/Item/index.tsx
@@ -1,30 +1,66 @@
-import { useParams } from 'react-router-dom';
-import { ArrowLink } from './components';
+import { useState, useEffect } from 'react';
+import { useLocation } from 'react-router-dom';
+import styled from 'styled-components';
+import { Header, Main, Footer, LPCover, AlbumInfo } from '@/common/components';
+import {
+  ProcessedResult,
+  ProcessedTracklist,
+  RawTracklist,
+} from '@/types/data';
+import axios from 'axios';
+
+const vaildator = (tracklist: RawTracklist[]) =>
+  tracklist.length !== 0 && Array.isArray(tracklist);
 
 export default function Item() {
-  const { isbn } = useParams();
+  const [tracklist, setTracklist] = useState({});
+  const location = useLocation();
+  const searchResult = location.state as ProcessedResult;
 
+  useEffect(() => {
+    async function fetchTrackList() {
+      try {
+        const res = await axios.get(searchResult.resourceURL);
+
+        setTracklist({
+          infoName: 'Tracklist',
+          infoContent: res.data.tracklist,
+          isValid: vaildator(res.data.tracklist),
+        });
+      } catch (error) {
+        console.log(error);
+      }
+    }
+    fetchTrackList();
+  }, []);
+
+  console.log(tracklist);
   return (
     <>
-      <h1>음반 상세정보</h1>
-      <div
-        style={{
-          width: '15rem',
-          height: '15rem',
-          margin: '2rem auto',
-          lineHeight: '15rem',
-          backgroundColor: 'lightgray',
-        }}
-      >
-        album cover
-      </div>
-      <div>artist: 가수 이름</div>
-      <div>album: 앨범 이름</div>
-      <div>release date: 발매일</div>
-      <div>genre: 장르</div>
-      <div>isbn number: {isbn}</div>
-      <div>track list: 트랙 리스트</div>
-      <ArrowLink />
+      <Header />
+      <Main>
+        <h1 className="srOnly">LP 상세 정보</h1>
+        <DetailWrapper>
+          <LPCover
+            searchResult={searchResult}
+            size="large"
+            hoverInteraction={false}
+          ></LPCover>
+          <AlbumInfo
+            searchResult={searchResult}
+            tracklist={tracklist as ProcessedTracklist}
+            page="all"
+            view="detail"
+          />
+        </DetailWrapper>
+      </Main>
+      <Footer />
     </>
   );
 }
+
+const DetailWrapper = styled.div`
+  width: min-content;
+  margin: 0 auto;
+  margin-top: 60px;
+`;

--- a/src/pages/SearchResult/index.tsx
+++ b/src/pages/SearchResult/index.tsx
@@ -18,7 +18,7 @@ import {
   VIEW_LABEL,
 } from '@/utils/constants/dropdown';
 import processResult from '@/utils/functions/processResult';
-import { ProcessResult } from '@/types/data';
+import { ProcessedResult } from '@/types/data';
 
 const SECRET = import.meta.env.VITE_API_SECRET;
 const KEY = import.meta.env.VITE_API_KEY;
@@ -26,7 +26,7 @@ const KEY = import.meta.env.VITE_API_KEY;
 export default function SearchResult() {
   const [searchParams] = useSearchParams();
   const [itemCount, setItemCount] = useState<number>(0);
-  const [result, setResult] = useState<ProcessResult[]>([]);
+  const [result, setResult] = useState<ProcessedResult[]>([]);
 
   const params = new URLSearchParams(window.location.search);
   const value = params.get('query');

--- a/src/types/data.ts
+++ b/src/types/data.ts
@@ -21,7 +21,8 @@ export interface RawResult {
   formats: string[];
 }
 
-export interface ProcessResult {
+export interface ProcessedResult {
+  id: number;
   titleInfo: { title: string; artist: string };
   detailInfo: {
     infoName: 'Country' | 'Genre' | 'Label' | 'Style' | 'Released';
@@ -30,4 +31,17 @@ export interface ProcessResult {
   }[];
   imgURL: string;
   resourceURL: string;
+}
+
+export interface RawTracklist {
+  position: string;
+  type_: string;
+  title: string;
+  duration: string;
+}
+
+export interface ProcessedTracklist {
+  infoName: 'Tracklist';
+  infoContent: RawTracklist[];
+  isValid: boolean;
 }

--- a/src/utils/constants/dropdown.ts
+++ b/src/utils/constants/dropdown.ts
@@ -10,7 +10,7 @@ export const SORT_CONTENT: DropdownContentType[] = [
   },
   {
     key: 'default',
-    value: '정확도',
+    value: '정확도순',
   },
   {
     key: 'date',
@@ -20,7 +20,7 @@ export const SORT_CONTENT: DropdownContentType[] = [
 
 export const SORT_LABEL = '정렬 방식 선택';
 
-export const VIEW_CONTENT = [
+export const VIEW_CONTENT: DropdownContentType[] = [
   {
     key: 'default',
     value: '보기 방식',

--- a/src/utils/functions/processResult.ts
+++ b/src/utils/functions/processResult.ts
@@ -1,4 +1,4 @@
-import { RawResult, ProcessResult } from '@/types/data';
+import { RawResult, ProcessedResult } from '@/types/data';
 
 const validator = (data: string | Array<string>) => {
   if (typeof data === 'string') {
@@ -10,9 +10,10 @@ const validator = (data: string | Array<string>) => {
   return false;
 };
 
-const processResult = (result: RawResult[]): ProcessResult[] =>
+const processResult = (result: RawResult[]): ProcessedResult[] =>
   result.map(
     ({
+      id,
       country,
       cover_image,
       genre,
@@ -25,6 +26,7 @@ const processResult = (result: RawResult[]): ProcessResult[] =>
       const [artist, albumTitle] = title.split(' - ');
 
       return {
+        id: id,
         titleInfo: { title: albumTitle, artist },
         detailInfo: [
           {

--- a/src/utils/mocks/mockInfo.ts
+++ b/src/utils/mocks/mockInfo.ts
@@ -1,9 +1,11 @@
 import { DetailInfoProps } from '@/common/components/DetailInfo/DetailInfo';
 
+const ellipsisString = '가나다라마바사아자차카타파하ABCDEFGHIJKLMNOPQRSTUVWXYZ';
+
 const mockTrackList = [
   {
     position: 'A1',
-    title: '가나다라마바사아자차카타파하ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+    title: ellipsisString,
     duration: '3:33',
   },
   { position: 'A2', title: '꽃', duration: '2:59' },
@@ -18,8 +20,8 @@ const mockTrackList = [
 const mockTitleInfo_default = { title: '꽃갈피', artist: 'IU' };
 
 const mockTitleInfo_ellipsis = {
-  title: '가나다라마바사아자차카타파하ABCDEFGHIJKLMNOPQRSTUVWXYZ',
-  artist: '가나다라마바사아자차카타파하ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+  title: ellipsisString,
+  artist: ellipsisString,
 };
 const mockDetailInfo_default: DetailInfoProps[] = [
   { infoName: 'Released', infoContent: '2014', isValid: true },
@@ -35,262 +37,63 @@ const mockDetailInfo_default: DetailInfoProps[] = [
   },
   { infoName: 'Country', infoContent: 'South Korea', isValid: true },
   { infoName: 'Label', infoContent: ['Loen Entertainment'], isValid: true },
-  { infoName: 'Tracklist', infoContent: mockTrackList, isValid: true },
 ];
 
 const mockDetailInfo_ellipsis: DetailInfoProps[] = [
   { infoName: 'Released', infoContent: '2014', isValid: true },
   {
     infoName: 'Genre',
-    infoContent: [
-      '가나다라마바사아자차카타파하ABCDEFGHIJKLMNOPQRSTUVWXYZ',
-      'Folk, World, & Country',
-    ],
+    infoContent: [ellipsisString, 'Folk, World, & Country'],
     isValid: true,
   },
   {
     infoName: 'Style',
-    infoContent: [
-      '가나다라마바사아자차카타파하ABCDEFGHIJKLMNOPQRSTUVWXYZ',
-      'Ballad',
-      'K-pop',
-    ],
+    infoContent: [ellipsisString, 'Ballad', 'K-pop'],
     isValid: true,
   },
   {
     infoName: 'Country',
-    infoContent: '가나다라마바사아자차카타파하ABCDEFGHIJKLMNOPQRSTUVWXYZ',
+    infoContent: ellipsisString,
     isValid: true,
   },
   {
     infoName: 'Label',
-    infoContent: ['가나다라마바사아자차카타파하ABCDEFGHIJKLMNOPQRSTUVWXYZ'],
+    infoContent: [ellipsisString],
     isValid: true,
   },
-  { infoName: 'Tracklist', infoContent: mockTrackList, isValid: true },
 ];
+
+const mockId = 112313213;
 
 const mockImgURL =
   'https://i.discogs.com/jgaM3Iwz2t05Whh7VHfdtqYtIseHo3mRqk1PQNIUsF0/rs:fit/g:sm/q:90/h:398/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYwMDg0/MDEtMTQwODY5NzMw/MS0zMzE2LmpwZWc.jpeg';
 
-const mockSearchResult = [
-  {
-    titleInfo: { title: '꽃갈피', artist: 'IU' },
-    detailInfo: [
-      { infoName: 'Released', infoContent: '2014', isValid: true },
-      {
-        infoName: 'Genre',
-        infoContent: ['Pop', 'Folk, World, & Country'],
-        isValid: true,
-      },
-      {
-        infoName: 'Style',
-        infoContent: ['Folk', 'Ballad', 'K-pop'],
-        isValid: true,
-      },
-      { infoName: 'Country', infoContent: 'South Korea', isValid: true },
-      { infoName: 'Label', infoContent: ['Loen Entertainment'], isValid: true },
-      { infoName: 'Tracklist', infoContent: mockTrackList, isValid: true },
-    ],
-    imgURL:
-      'https://i.discogs.com/jgaM3Iwz2t05Whh7VHfdtqYtIseHo3mRqk1PQNIUsF0/rs:fit/g:sm/q:90/h:398/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYwMDg0/MDEtMTQwODY5NzMw/MS0zMzE2LmpwZWc.jpeg',
-  },
-  {
-    titleInfo: { title: '꽃갈피', artist: 'IU' },
-    detailInfo: [
-      { infoName: 'Released', infoContent: '2014', isValid: true },
-      {
-        infoName: 'Genre',
-        infoContent: ['Pop', 'Folk, World, & Country'],
-        isValid: true,
-      },
-      {
-        infoName: 'Style',
-        infoContent: ['Folk', 'Ballad', 'K-pop'],
-        isValid: true,
-      },
-      { infoName: 'Country', infoContent: 'South Korea', isValid: true },
-      { infoName: 'Label', infoContent: ['Loen Entertainment'], isValid: true },
-      { infoName: 'Tracklist', infoContent: mockTrackList, isValid: true },
-    ],
-    imgURL:
-      'https://i.discogs.com/jgaM3Iwz2t05Whh7VHfdtqYtIseHo3mRqk1PQNIUsF0/rs:fit/g:sm/q:90/h:398/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYwMDg0/MDEtMTQwODY5NzMw/MS0zMzE2LmpwZWc.jpeg',
-  },
-  {
-    titleInfo: { title: '꽃갈피', artist: 'IU' },
-    detailInfo: [
-      { infoName: 'Released', infoContent: '2014', isValid: true },
-      {
-        infoName: 'Genre',
-        infoContent: ['Pop', 'Folk, World, & Country'],
-        isValid: true,
-      },
-      {
-        infoName: 'Style',
-        infoContent: ['Folk', 'Ballad', 'K-pop'],
-        isValid: true,
-      },
-      { infoName: 'Country', infoContent: 'South Korea', isValid: true },
-      { infoName: 'Label', infoContent: ['Loen Entertainment'], isValid: true },
-      { infoName: 'Tracklist', infoContent: mockTrackList, isValid: true },
-    ],
-    imgURL:
-      'https://i.discogs.com/jgaM3Iwz2t05Whh7VHfdtqYtIseHo3mRqk1PQNIUsF0/rs:fit/g:sm/q:90/h:398/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYwMDg0/MDEtMTQwODY5NzMw/MS0zMzE2LmpwZWc.jpeg',
-  },
-  {
-    titleInfo: { title: '꽃갈피', artist: 'IU' },
-    detailInfo: [
-      { infoName: 'Released', infoContent: '2014', isValid: true },
-      {
-        infoName: 'Genre',
-        infoContent: ['Pop', 'Folk, World, & Country'],
-        isValid: true,
-      },
-      {
-        infoName: 'Style',
-        infoContent: ['Folk', 'Ballad', 'K-pop'],
-        isValid: true,
-      },
-      { infoName: 'Country', infoContent: 'South Korea', isValid: true },
-      { infoName: 'Label', infoContent: ['Loen Entertainment'], isValid: true },
-      { infoName: 'Tracklist', infoContent: mockTrackList, isValid: true },
-    ],
-    imgURL:
-      'https://i.discogs.com/jgaM3Iwz2t05Whh7VHfdtqYtIseHo3mRqk1PQNIUsF0/rs:fit/g:sm/q:90/h:398/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYwMDg0/MDEtMTQwODY5NzMw/MS0zMzE2LmpwZWc.jpeg',
-  },
-  {
-    titleInfo: { title: '꽃갈피', artist: 'IU' },
-    detailInfo: [
-      { infoName: 'Released', infoContent: '2014', isValid: true },
-      {
-        infoName: 'Genre',
-        infoContent: ['Pop', 'Folk, World, & Country'],
-        isValid: true,
-      },
-      {
-        infoName: 'Style',
-        infoContent: ['Folk', 'Ballad', 'K-pop'],
-        isValid: true,
-      },
-      { infoName: 'Country', infoContent: 'South Korea', isValid: true },
-      { infoName: 'Label', infoContent: ['Loen Entertainment'], isValid: true },
-      { infoName: 'Tracklist', infoContent: mockTrackList, isValid: true },
-    ],
-    imgURL:
-      'https://i.discogs.com/jgaM3Iwz2t05Whh7VHfdtqYtIseHo3mRqk1PQNIUsF0/rs:fit/g:sm/q:90/h:398/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYwMDg0/MDEtMTQwODY5NzMw/MS0zMzE2LmpwZWc.jpeg',
-  },
-  {
-    titleInfo: { title: '꽃갈피', artist: 'IU' },
-    detailInfo: [
-      { infoName: 'Released', infoContent: '2014', isValid: true },
-      {
-        infoName: 'Genre',
-        infoContent: ['Pop', 'Folk, World, & Country'],
-        isValid: true,
-      },
-      {
-        infoName: 'Style',
-        infoContent: ['Folk', 'Ballad', 'K-pop'],
-        isValid: true,
-      },
-      { infoName: 'Country', infoContent: 'South Korea', isValid: true },
-      { infoName: 'Label', infoContent: ['Loen Entertainment'], isValid: true },
-      { infoName: 'Tracklist', infoContent: mockTrackList, isValid: true },
-    ],
-    imgURL:
-      'https://i.discogs.com/jgaM3Iwz2t05Whh7VHfdtqYtIseHo3mRqk1PQNIUsF0/rs:fit/g:sm/q:90/h:398/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYwMDg0/MDEtMTQwODY5NzMw/MS0zMzE2LmpwZWc.jpeg',
-  },
-  {
-    titleInfo: { title: '꽃갈피', artist: 'IU' },
-    detailInfo: [
-      { infoName: 'Released', infoContent: '2014', isValid: true },
-      {
-        infoName: 'Genre',
-        infoContent: ['Pop', 'Folk, World, & Country'],
-        isValid: true,
-      },
-      {
-        infoName: 'Style',
-        infoContent: ['Folk', 'Ballad', 'K-pop'],
-        isValid: true,
-      },
-      { infoName: 'Country', infoContent: 'South Korea', isValid: true },
-      { infoName: 'Label', infoContent: ['Loen Entertainment'], isValid: true },
-      { infoName: 'Tracklist', infoContent: mockTrackList, isValid: true },
-    ],
-    imgURL:
-      'https://i.discogs.com/jgaM3Iwz2t05Whh7VHfdtqYtIseHo3mRqk1PQNIUsF0/rs:fit/g:sm/q:90/h:398/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYwMDg0/MDEtMTQwODY5NzMw/MS0zMzE2LmpwZWc.jpeg',
-  },
-  {
-    titleInfo: { title: '꽃갈피', artist: 'IU' },
-    detailInfo: [
-      { infoName: 'Released', infoContent: '2014', isValid: true },
-      {
-        infoName: 'Genre',
-        infoContent: ['Pop', 'Folk, World, & Country'],
-        isValid: true,
-      },
-      {
-        infoName: 'Style',
-        infoContent: ['Folk', 'Ballad', 'K-pop'],
-        isValid: true,
-      },
-      { infoName: 'Country', infoContent: 'South Korea', isValid: true },
-      { infoName: 'Label', infoContent: ['Loen Entertainment'], isValid: true },
-      { infoName: 'Tracklist', infoContent: mockTrackList, isValid: true },
-    ],
-    imgURL:
-      'https://i.discogs.com/jgaM3Iwz2t05Whh7VHfdtqYtIseHo3mRqk1PQNIUsF0/rs:fit/g:sm/q:90/h:398/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYwMDg0/MDEtMTQwODY5NzMw/MS0zMzE2LmpwZWc.jpeg',
-  },
-  {
-    titleInfo: { title: '꽃갈피', artist: 'IU' },
-    detailInfo: [
-      { infoName: 'Released', infoContent: '2014', isValid: true },
-      {
-        infoName: 'Genre',
-        infoContent: ['Pop', 'Folk, World, & Country'],
-        isValid: true,
-      },
-      {
-        infoName: 'Style',
-        infoContent: ['Folk', 'Ballad', 'K-pop'],
-        isValid: true,
-      },
-      { infoName: 'Country', infoContent: 'South Korea', isValid: true },
-      { infoName: 'Label', infoContent: ['Loen Entertainment'], isValid: true },
-      { infoName: 'Tracklist', infoContent: mockTrackList, isValid: true },
-    ],
-    imgURL:
-      'https://i.discogs.com/jgaM3Iwz2t05Whh7VHfdtqYtIseHo3mRqk1PQNIUsF0/rs:fit/g:sm/q:90/h:398/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYwMDg0/MDEtMTQwODY5NzMw/MS0zMzE2LmpwZWc.jpeg',
-  },
-  {
-    titleInfo: { title: '꽃갈피', artist: 'IU' },
-    detailInfo: [
-      { infoName: 'Released', infoContent: '2014', isValid: true },
-      {
-        infoName: 'Genre',
-        infoContent: ['Pop', 'Folk, World, & Country'],
-        isValid: true,
-      },
-      {
-        infoName: 'Style',
-        infoContent: ['Folk', 'Ballad', 'K-pop'],
-        isValid: true,
-      },
-      { infoName: 'Country', infoContent: 'South Korea', isValid: true },
-      { infoName: 'Label', infoContent: ['Loen Entertainment'], isValid: true },
-      { infoName: 'Tracklist', infoContent: mockTrackList, isValid: true },
-    ],
-    imgURL:
-      'https://i.discogs.com/jgaM3Iwz2t05Whh7VHfdtqYtIseHo3mRqk1PQNIUsF0/rs:fit/g:sm/q:90/h:398/w:400/czM6Ly9kaXNjb2dz/LWRhdGFiYXNlLWlt/YWdlcy9SLTYwMDg0/MDEtMTQwODY5NzMw/MS0zMzE2LmpwZWc.jpeg',
-  },
-];
+const mockResourceURL = 'https://www.naver.com';
+
+const mockSearchResult_default = {
+  id: mockId,
+  titleInfo: mockTitleInfo_default,
+  detailInfo: mockDetailInfo_default,
+  imgURL: mockImgURL,
+  resourceURL: mockResourceURL,
+};
+
+const mockSearchResult_ellipsis = {
+  id: mockId,
+  titleInfo: mockTitleInfo_ellipsis,
+  detailInfo: mockDetailInfo_ellipsis,
+  imgURL: mockImgURL,
+  resourceURL: mockResourceURL,
+};
+
+const mockSearchResults = Array.from({ length: 10 }).fill(
+  mockDetailInfo_default
+);
 
 export {
-  mockTitleInfo_default,
-  mockTitleInfo_ellipsis,
-  mockDetailInfo_default,
-  mockDetailInfo_ellipsis,
+  mockTrackList,
+  mockSearchResult_default,
+  mockSearchResult_ellipsis,
   mockImgURL,
-  mockSearchResult,
+  mockSearchResults,
 };


### PR DESCRIPTION
## PR Type
- [x] FEAT: 새로운 기능 구현
- [x] FIX: 버그 수정
- [ ] DOCS: 문서 추가 및 수정
- [x] STYLE: 포맷팅 변경
- [x] REFACTOR: 코드 리팩토링
- [x] TEST: 테스트 관련
- [ ] DEPLOY: 배포 관련
- [ ] CHORE: 빌드, 환경 설정 등 기타 작업

## Abstracts
* 전체 검색 결과의 개별 정보를 클릭했을 때 이동되는 상세 페이지를 구현했습니다. 
* 변경된 데이터 구조에 따라 페이지에 포함된 하위 컴포넌트들을 전면 수정했습니다.

## Description
### 작업 내용
- 컴포넌트에 사용할 타입 재정의
- releaseURL로 호출한 데이터의 타입 정의
- API로 호출한 데이터를 가공하는 함수 추가
- 가공된 데이터 구조 갱신
- 쿼리 스트링 값에 따라 컴포넌트가 리렌더링 되도록 로직 작성
- 하위 컴포넌트들을 조립하여 검색 결과 페이지 완성
- 하위 컴포넌트 조립 과정에서 발생한 props, 관련 관련 오류 해결
- 컴포넌트 및 페이지 스타일링

### API로 호출한 raw 데이터 타입
```typescript
export interface RawTracklist {
  position: string;
  type_: string;
  title: string;
  duration: string;
}
```

### 데이터 가공 결과
![image](https://user-images.githubusercontent.com/101828759/206911887-ddc7c31f-e971-43d9-b59a-83a9d4531a0e.png)

### 가공된 데이터 타입
```typescript
export interface ProcessedTracklist {
  infoName: 'Tracklist';
  infoContent: RawTracklist[];
  isValid: boolean;
}
```

### 컴포넌트 구조
```jsx
<SearchResult>
  <Header />
  <Main>
    <h1></h1>
    <SearchResultWrapper>
      <SearchResultText />
      <Dropdown />
      <Dropdown />
    </SearchResultWrapper>
    <VinylItems />
  </Main>
  <Footer />
</SearchResult>
```
### 트러블 슈팅
* [관련 노션 문서 참조](https://chaerin-dev.notion.site/ebe7ec50e9e1411ca4a38863552d3c52)

### 구현 이미지
![image](https://user-images.githubusercontent.com/101828759/206912156-d6b6771c-8b04-49a7-a88a-d021bb27c946.png)

## Discussion
* `width`, `height` 관련 컨벤션 논의 필요합니다.
* 타입 재정의 및 분리가 필요합니다.


---
Close #79 
