### PR TITLE
로그인 유저의 Redirection & Floating 애니메이션 구현

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "start": "vite --host --open",
     "dev": "vite --host",
     "build": "tsc && vite build",
-    "preview": "vite preview --port 8080",
+    "preview": "vite preview --port 8080 --open",
     "storybook": "start-storybook -p 6006",
     "build-storybook": "build-storybook"
   },

--- a/src/pages/Home/index.tsx
+++ b/src/pages/Home/index.tsx
@@ -1,16 +1,22 @@
 import styled from 'styled-components';
 import { Header, SearchInput, Footer, Main } from '@/common/components';
 import useHandleSubmit from './../../hooks/useHandleSubmit';
+import { motion } from 'framer-motion';
+import { FLOATING_MOTION_VALUE } from '@/utils/constants/motion';
 
 export default function Home() {
+  const { initial, animate, transition } = FLOATING_MOTION_VALUE;
+
   return (
     <>
       <Header />
       <StyledMain>
-        <Catchphrase>
-          Record your <HighLight>Records!</HighLight>
-        </Catchphrase>
-        <SearchInput handleSubmit={useHandleSubmit()} />
+        <motion.div initial={initial} animate={animate} transition={transition}>
+          <Catchphrase>
+            Record your <HighLight>Records!</HighLight>
+          </Catchphrase>
+          <SearchInput handleSubmit={useHandleSubmit()} />
+        </motion.div>
       </StyledMain>
       <Footer />
     </>
@@ -27,7 +33,7 @@ const StyledMain = styled(Main)`
   padding-bottom: 64px;
 `;
 
-const Catchphrase = styled.h2`
+const Catchphrase = styled(motion.h2)`
   margin-bottom: var(--space-xs);
   width: 100%;
   font-size: 2rem;

--- a/src/pages/MyCollections/index.tsx
+++ b/src/pages/MyCollections/index.tsx
@@ -1,6 +1,12 @@
-import { useParams } from 'react-router-dom';
 import uuid from 'react-uuid';
+import { useEffect, useState } from 'react';
+import { useParams } from 'react-router-dom';
 import styled from 'styled-components';
+import { motion } from 'framer-motion';
+import { useRecoilState } from 'recoil';
+import { dialogState, createCollectionDialogState } from '@/recoil/globalState';
+// import { mockUsersData } from '@/utils/mocks/mockInfo';
+import axios from 'axios';
 import {
   Header,
   Main,
@@ -9,11 +15,15 @@ import {
   Footer,
 } from '@/common/components';
 import { Bookshelf } from './components';
-import { useRecoilState } from 'recoil';
-import { dialogState, createCollectionDialogState } from '@/recoil/globalState';
-// import { mockUsersData } from '@/utils/mocks/mockInfo';
-import axios from 'axios';
-import { useEffect, useState } from 'react';
+
+const MOTION_VALUE = {
+  initial: { y: '30px', opacity: 0 },
+  animate: { y: 0, opacity: 1 },
+  transition: {
+    duration: 1,
+    ease: 'easeOut',
+  },
+};
 
 const MyCollectionsPageTitle = styled(PageTitle)`
   margin-top: 56px;
@@ -56,29 +66,33 @@ export default function MyCollections() {
     fetchResults();
   }, []);
 
+  const { initial, animate, transition } = MOTION_VALUE;
+
   return (
     <>
       <Header />
       <Main>
-        <MyCollectionsPageTitle>{`${userNickName}'s Collections`}</MyCollectionsPageTitle>
-        <CollectionsWrapper style={{ width: '520px' }}>
-          <AddCollectionButton
-            onClick={() => setDialog(createCollectionDialogState)}
-            size="large"
-          />
-          {userCollections.map(({ title, collectionId, vinylCount }) => {
-            const newUuid = uuid();
-            return (
-              <Bookshelf
-                key={newUuid}
-                userId={+(userid as string)}
-                collectionId={collectionId}
-                title={title}
-                count={vinylCount}
-              ></Bookshelf>
-            );
-          })}
-        </CollectionsWrapper>
+        <motion.div initial={initial} animate={animate} transition={transition}>
+          <MyCollectionsPageTitle>{`${userNickName}'s Collections`}</MyCollectionsPageTitle>
+          <CollectionsWrapper style={{ width: '520px' }}>
+            <AddCollectionButton
+              onClick={() => setDialog(createCollectionDialogState)}
+              size="large"
+            />
+            {userCollections.map(({ title, collectionId, vinylCount }) => {
+              const newUuid = uuid();
+              return (
+                <Bookshelf
+                  key={newUuid}
+                  userId={+(userid as string)}
+                  collectionId={collectionId}
+                  title={title}
+                  count={vinylCount}
+                ></Bookshelf>
+              );
+            })}
+          </CollectionsWrapper>
+        </motion.div>
       </Main>
       <Footer />
     </>

--- a/src/pages/NotFound/components/BrokenVinyls/BrokenVinyls.tsx
+++ b/src/pages/NotFound/components/BrokenVinyls/BrokenVinyls.tsx
@@ -1,25 +1,14 @@
 import uuid from 'react-uuid';
 import styled, { keyframes } from 'styled-components';
 import { motion } from 'framer-motion';
-
-export interface MotionValueType {
-  [key: number]: { x: string; y: string; scale: number };
-}
-
-const MOTION_VALUE: MotionValueType = {
-  1: { x: '-5px', y: '-5px', scale: 1 },
-  2: { x: '8px', y: '-5px', scale: 1 },
-  3: { x: '8px', y: '8px', scale: 1 },
-  4: { x: '-12px', y: '16px', scale: 1 },
-  5: { x: '-2px', y: '10px', scale: 1 },
-};
+import { BROKEN_MOTION_VALUE } from '@/utils/constants/motion';
 
 export default function BrokenVinyls() {
   return (
     <BrokenVinylsWrapper>
       {Array.from({ length: 5 }).map((_, index) => {
         const path = `/assets/broken_vinyl_${index + 1}.svg`;
-        const { x, y, scale } = MOTION_VALUE[index + 1];
+        const { x, y, scale } = BROKEN_MOTION_VALUE[index + 1];
 
         return (
           <BrokenVinyl

--- a/src/pages/Signin/index.tsx
+++ b/src/pages/Signin/index.tsx
@@ -7,7 +7,7 @@ import {
 } from '@/common/components';
 import axios from 'axios';
 import { useNavigate } from 'react-router-dom';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useLayoutEffect } from 'react';
 
 const HeaderLogo = styled(LogoLink)`
   margin-bottom: 24px;
@@ -23,11 +23,25 @@ const FormContainer = styled.div`
   margin-top: 20vh;
 `;
 
-const url = `http://localhost:3313/signin`;
+const authRequestUrl = 'http://localhost:3313/auth';
+const signinRequestUrl = `http://localhost:3313/signin`;
 
 export default function Signin() {
   const [checkEmail, setCheckEmail] = useState('');
   const navigate = useNavigate();
+
+  useLayoutEffect(() => {
+    async function auth() {
+      const {
+        data: { isLogin },
+      } = await axios.get(authRequestUrl, {
+        withCredentials: true,
+      });
+
+      isLogin && navigate('/');
+    }
+    auth();
+  }, []);
 
   useEffect(() => {
     checkEmail === 'needAuth' &&
@@ -46,7 +60,11 @@ export default function Signin() {
     const password = (e.currentTarget[1] as HTMLInputElement).value;
     const {
       data: { userId, state },
-    } = await axios.post(url, { email, password }, { withCredentials: true });
+    } = await axios.post(
+      signinRequestUrl,
+      { email, password },
+      { withCredentials: true }
+    );
     if (userId) navigate('/');
     else setCheckEmail(state);
   };

--- a/src/utils/constants/motion.ts
+++ b/src/utils/constants/motion.ts
@@ -1,0 +1,20 @@
+export interface BrokenMotionValueType {
+  [key: number]: { x: string; y: string; scale: number };
+}
+
+export const BROKEN_MOTION_VALUE: BrokenMotionValueType = {
+  1: { x: '-5px', y: '-5px', scale: 1 },
+  2: { x: '8px', y: '-5px', scale: 1 },
+  3: { x: '8px', y: '8px', scale: 1 },
+  4: { x: '-12px', y: '16px', scale: 1 },
+  5: { x: '-2px', y: '10px', scale: 1 },
+};
+
+export const FLOATING_MOTION_VALUE = {
+  initial: { y: '30px', opacity: 0 },
+  animate: { y: 0, opacity: 1 },
+  transition: {
+    duration: 1,
+    ease: 'easeOut',
+  },
+};

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -26,4 +26,12 @@ export default defineConfig({
     }),
   ],
   logLevel: 'error',
+  build: {
+    rollupOptions: {
+      output: {
+        chunkFileNames: '[name]-[hash].js',
+        entryFileNames: '[name]-[hash].js',
+      },
+    },
+  },
 });


### PR DESCRIPTION
## PR Type
- [x] FEAT: 새로운 기능 구현
- [ ] FIX: 버그 수정
- [ ] DOCS: 문서 추가 및 수정
- [ ] STYLE: 포맷팅 변경
- [x] REFACTOR: 코드 리팩토링
- [ ] TEST: 테스트 관련
- [ ] DEPLOY: 배포 관련
- [x] CHORE: 빌드, 환경 설정 등 기타 작업

## Abstracts
* 로그인 유저가 signin url에 접근하면 main 페이지로  redirection 되는 기능을 구현합니다.
* main 페이지와 my collections 페이지의 Floating 애니메이션을 구현합니다.

## Description
### 작업 내용
- 로그인 유저의 redirection 기능 구현
- Floating 애니메이션 구현
- 애니메이션 관련 상수 값 정리
- build 옵션 추가하여 js 파일을 assets 폴더 밖으로 분리 

### 구현 이미지
* 변경된 dist 폴더 구조
![image](https://user-images.githubusercontent.com/101828759/208703937-4494896e-6480-4361-a917-b900309f1af5.png)

* Floating 애니메이션
![floating](https://user-images.githubusercontent.com/101828759/208714715-ca4d0a21-1e8c-48ff-a40f-e12446d49faf.gif)
![floating2](https://user-images.githubusercontent.com/101828759/208715575-ac0f45b8-092a-4605-8bdb-f9866158b144.gif)


## Discussion
* dist 폴더 구조를 변경해도 preview 시 개발자 도구의 소스에서 환경 변수 값이 여전히 노출되므로 다른 해결 방법을 찾아야 할 듯함

---
Close #143 
