### PR TITLE
LogoLink, SquareButton, SquareLink 컴포넌트 리팩토링

### DIFF
--- a/.storybook/preview.jsx
+++ b/.storybook/preview.jsx
@@ -1,6 +1,6 @@
 import { RecoilRoot } from 'recoil';
-import { GlobalStyle } from '../src/common/styles/globalStyle';
-import { NormalizeStyle } from '../src/common/styles/normalizeStyle';
+import { GlobalStyle } from '../src/styles/globalStyle';
+import { NormalizeStyle } from '../src/styles/normalizeStyle';
 import { withRouter } from 'storybook-addon-react-router-v6';
 import ko from 'axe-core/locales/ko.json';
 

--- a/src/components/layout/Header/Header.tsx
+++ b/src/components/layout/Header/Header.tsx
@@ -1,8 +1,9 @@
+import React from 'react';
+import { useRecoilValue } from 'recoil';
+import { loginState, userState } from '@/recoil/globalState';
 import styled from 'styled-components';
 import { LogoLink, SearchInput, SquareLink, ProfileLink } from '@/components';
 import useHandleSubmit from '@/hooks/useHandleSubmit';
-import { useRecoilValue } from 'recoil';
-import { loginState, userState } from '@/recoil/globalState';
 
 function Header({ ...props }) {
   const isLogIn = useRecoilValue(loginState);
@@ -20,10 +21,7 @@ function Header({ ...props }) {
         <SearchInput inputSize="small" handleSubmit={SearchInputRender} />
       )}
       {isLogIn !== undefined && (
-        <SquareLink
-          link={isLogIn ? `/mycollections/${userId}` : '/signin'}
-          width={178}
-        >
+        <SquareLink link={isLogIn ? `/mycollections/${userId}` : '/signin'}>
           My Collections
         </SquareLink>
       )}
@@ -32,11 +30,9 @@ function Header({ ...props }) {
           <ProfileLink />
         ) : (
           <SquareLink
-            backgroundColor="var(--white)"
-            color="var(--purple-900)"
             link={isLogIn ? `/mycollections/${userId}` : '/signin'}
-            transition
-            width={97}
+            $isFilled={false}
+            $isTransition={true}
           >
             Sign In
           </SquareLink>

--- a/src/components/shared/LogoLink/LogoLink.stories.tsx
+++ b/src/components/shared/LogoLink/LogoLink.stories.tsx
@@ -17,12 +17,12 @@ export default {
   },
   argTypes: {
     width: {
-      description: '로고의 너비 지정',
+      description: '너비 지정',
       control: 'select',
       options: ['74px', '100px', '132px'],
     },
     height: {
-      description: '로고의 높이 지정',
+      description: '높이 지정',
       control: 'select',
       options: ['40px', '54px', '72px'],
     },

--- a/src/components/shared/LogoLink/LogoLink.stories.tsx
+++ b/src/components/shared/LogoLink/LogoLink.stories.tsx
@@ -2,11 +2,29 @@ import { ComponentStory, ComponentMeta } from '@storybook/react';
 import LogoLink from './LogoLink';
 
 export default {
-  title: 'common/components/LogoLink',
+  title: 'components/shared/LogoLink',
   component: LogoLink,
   parameters: {
+    docs: {
+      description: {
+        component:
+          '33 1/3의 로고를 나타내며, 클릭 시 홈페이지로 이동하는 컴포넌트입니다.',
+      },
+    },
     design: {
       url: 'https://www.figma.com/file/y5dq4m439YJKRTrKw5ZsZV/33-1%2F3?node-id=129%3A28&t=ri42uDzp7Wjgw7vi-4',
+    },
+  },
+  argTypes: {
+    width: {
+      description: '로고의 너비 지정',
+      control: 'select',
+      options: ['74px', '100px', '132px'],
+    },
+    height: {
+      description: '로고의 높이 지정',
+      control: 'select',
+      options: ['40px', '54px', '72px'],
     },
   },
 } as ComponentMeta<typeof LogoLink>;
@@ -15,14 +33,20 @@ const Template: ComponentStory<typeof LogoLink> = (args) => (
   <LogoLink {...args} />
 );
 
-export const Large = Template.bind({});
-Large.args = {
+export const Header = Template.bind({});
+Header.args = {
+  width: '74px',
+  height: '40px',
+};
+
+export const SignInAndUp = Template.bind({});
+SignInAndUp.args = {
   width: '132px',
   height: '72px',
 };
 
-export const Small = Template.bind({});
-Small.args = {
-  width: '74px',
-  height: '40px',
+export const NotFound = Template.bind({});
+NotFound.args = {
+  width: '100px',
+  height: '54px',
 };

--- a/src/components/shared/LogoLink/LogoLink.tsx
+++ b/src/components/shared/LogoLink/LogoLink.tsx
@@ -1,23 +1,19 @@
-import { Link } from 'react-router-dom';
 import { memo } from 'react';
+import { Link } from 'react-router-dom';
 
 export interface LogoProps {
   width: string | number;
   height: string | number;
 }
 
-function LogoLink({ width, height, ...args }: LogoProps) {
+const LOGO_PATH = '/assets/logo.svg';
+
+const LogoLink = ({ width, height }: LogoProps) => {
   return (
-    <Link to="/" aria-label="메인 화면으로 이동">
-      <img
-        src="/assets/logo.svg"
-        alt="Thirty Three Third"
-        width={width}
-        height={height}
-        {...args}
-      />
+    <Link to="/" aria-label="홈페이지로 이동">
+      <img src={LOGO_PATH} alt="" width={width} height={height} />
     </Link>
   );
-}
+};
 
 export default memo(LogoLink);

--- a/src/components/shared/SquareButton/SquareButton.stories.tsx
+++ b/src/components/shared/SquareButton/SquareButton.stories.tsx
@@ -1,4 +1,5 @@
-import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import React from 'react';
+import { ComponentMeta, ComponentStory } from '@storybook/react';
 import SquareButton from './SquareButton';
 
 export default {

--- a/src/components/shared/SquareButton/SquareButton.stories.tsx
+++ b/src/components/shared/SquareButton/SquareButton.stories.tsx
@@ -2,19 +2,67 @@ import type { ComponentMeta, ComponentStory } from '@storybook/react';
 import SquareButton from './SquareButton';
 
 export default {
-  title: 'common/components/SqaureButton',
+  title: 'components/shared/SqaureButton',
+  parameters: {
+    docs: {
+      description: {
+        component: '서비스 내에서 주로 사용되는 사각형 버튼 컴포넌트입니다.',
+      },
+    },
+  },
   args: {
     fontSize: 20,
     size: 'small',
     isFilled: true,
   },
   argTypes: {
+    fontSize: {
+      description: '내부 텍스트 크기 지정',
+      table: {
+        type: {
+          summary: 'number',
+        },
+        defaultValue: {
+          summary: '20',
+        },
+      },
+    },
     size: {
+      description: '컴포넌트 자체의 크기 지정',
+      table: {
+        type: {
+          summary: `'small' | 'large'`,
+        },
+        defaultValue: {
+          summary: `'small'`,
+        },
+      },
       options: ['small', 'large'],
       control: { type: 'radio' },
     },
+    isFilled: {
+      description: '배경 색 여부 지정',
+      table: {
+        type: {
+          summary: 'boolean',
+        },
+        defaultValue: {
+          summary: 'true',
+        },
+      },
+    },
+    children: {
+      description: '내부 텍스트 내용 지정',
+      table: {
+        type: {
+          summary: 'string',
+        },
+        defaultValue: {
+          summary: `'버튼'`,
+        },
+      },
+    },
   },
-  component: SquareButton,
 } as ComponentMeta<typeof SquareButton>;
 
 const Template: ComponentStory<typeof SquareButton> = (args) => (

--- a/src/components/shared/SquareButton/SquareButton.tsx
+++ b/src/components/shared/SquareButton/SquareButton.tsx
@@ -1,6 +1,4 @@
-import styled from 'styled-components';
-
-const PADDING_VALUE = { small: '10px 16px', large: '12px 24px' };
+import styled, { css } from 'styled-components';
 
 export interface SquareButtonProps {
   fontSize: number;
@@ -9,32 +7,47 @@ export interface SquareButtonProps {
   children: string;
 }
 
-const SquareButton = styled.button<SquareButtonProps>`
-  padding: ${({ size }) => PADDING_VALUE[size]};
-  background-color: ${({ isFilled }) =>
-    isFilled ? 'var(--purple-900)' : 'var(--white)'};
-  border: ${({ isFilled }) =>
-    isFilled ? 'none' : '1px solid var(--purple-900)'};
-  border-radius: 6px;
-  font-weight: 700;
-  text-align: center;
-  font-size: ${({ fontSize }) => fontSize}px;
-  color: ${({ isFilled }) => (isFilled ? 'var(--white)' : 'var(--purple-900)')};
-  cursor: pointer;
-
-  &:disabled {
+const PADDING_VALUE = Object.freeze({ small: '10px 16px', large: '12px 24px' });
+const BUTTON_STYLE = Object.freeze({
+  isFilled: css`
+    background-color: var(--purple-900);
+    border: none;
+    color: var(--white);
+  `,
+  isNotFilled: css`
+    background-color: var(--white);
+    border: 1px solid var(--purple-900);
+    color: var(--purple-900);
+  `,
+  disabled: css`
     background-color: var(--gray-100);
     border: none;
     color: var(--gray-300);
+  `,
+});
+
+const SquareButton = styled.button<SquareButtonProps>`
+  ${({ isFilled }) =>
+    isFilled ? BUTTON_STYLE.isFilled : BUTTON_STYLE.isNotFilled}
+  width: fit-content;
+  padding: ${({ size }) => PADDING_VALUE[size]};
+  border-radius: 6px;
+  font-size: ${({ fontSize }) => fontSize}px;
+  font-weight: 700;
+  text-align: center;
+  cursor: pointer;
+
+  &:disabled {
+    ${BUTTON_STYLE.disabled}
     cursor: not-allowed;
   }
 `;
 
-SquareButton.defaultProps = {
+SquareButton.defaultProps = Object.freeze({
   fontSize: 20,
   size: 'small',
   isFilled: true,
   children: '버튼',
-};
+});
 
 export default SquareButton;

--- a/src/components/shared/SquareLink/SquareLink.stories.tsx
+++ b/src/components/shared/SquareLink/SquareLink.stories.tsx
@@ -1,39 +1,105 @@
+import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
 import SquareLink from './SquareLink';
 
 export default {
-  title: 'common/components/SquareLink',
-  component: SquareLink,
+  title: 'components/shared/SquareLink',
+  parameters: {
+    docs: {
+      description: {
+        component: 'Header에 사용되는 사각형 링크 컴포넌트입니다.',
+      },
+    },
+  },
+  args: {
+    link: '/',
+    children: '',
+    $fontSize: 20,
+    $isFilled: true,
+    $isTransition: false,
+  },
+  argTypes: {
+    link: {
+      description: '클릭 시 이동할 경로 지정',
+      table: {
+        type: {
+          summary: 'string',
+        },
+        defaultValue: {
+          summary: `'/'`,
+        },
+      },
+    },
+    $fontSize: {
+      description: '내부 텍스트 크기 지정',
+      table: {
+        type: {
+          summary: 'number',
+        },
+        defaultValue: {
+          summary: 20,
+        },
+      },
+      control: { type: 'number', min: 20, max: 60 },
+    },
+    $isFilled: {
+      description: '배경 색 여부 지정',
+      table: {
+        type: {
+          summary: 'boolean',
+        },
+        defaultValue: {
+          summary: 'true',
+        },
+      },
+      control: { type: 'boolean' },
+    },
+    $isTransition: {
+      description: 'hover 혹은 focus 시 트랜지션 여부 지정',
+      table: {
+        type: {
+          summary: 'boolean',
+        },
+        defaultValue: {
+          summary: 'true',
+        },
+      },
+      control: { type: 'boolean' },
+    },
+    children: {
+      description: '내부 텍스트 내용 지정',
+      table: {
+        type: {
+          summary: 'string',
+        },
+      },
+    },
+  },
 } as ComponentMeta<typeof SquareLink>;
 
 const Template: ComponentStory<typeof SquareLink> = (args) => (
   <SquareLink {...args} />
 );
 
-export const Prime = Template.bind({});
-Prime.args = {
+export const MyCollections = Template.bind({});
+MyCollections.args = {
   link: '/',
-  width: 178,
-  height: 40,
   children: 'My Collections',
 };
-Prime.parameters = {
+MyCollections.parameters = {
   design: {
     url: 'https://www.figma.com/file/y5dq4m439YJKRTrKw5ZsZV/33-1%2F3?node-id=116%3A25&t=ri42uDzp7Wjgw7vi-4',
   },
 };
 
-export const White = Template.bind({});
-White.args = {
-  link: '/',
-  width: 97,
-  height: 40,
+export const SignIn = Template.bind({});
+SignIn.args = {
+  link: '/signin',
   children: 'Sign In',
-  backgroundColor: 'var(--white)',
-  color: 'var(--purple-900)',
-  transition: true,
+  $isFilled: false,
+  $isTransition: true,
 };
-White.parameters = {
+SignIn.parameters = {
   design: {
     url: 'https://www.figma.com/file/y5dq4m439YJKRTrKw5ZsZV/33-1%2F3?node-id=133%3A294&t=ri42uDzp7Wjgw7vi-4',
   },

--- a/src/components/shared/SquareLink/SquareLink.tsx
+++ b/src/components/shared/SquareLink/SquareLink.tsx
@@ -1,84 +1,71 @@
-import styled from 'styled-components';
-import { memo } from 'react';
+import React, { memo } from 'react';
 import { Link } from 'react-router-dom';
+import styled, { css } from 'styled-components';
 
-export interface SquareLinkProps extends StyledLinkProps {
-  link: string;
-  width: string | number;
-  height: string | number;
-  children: string;
+export interface StyledLinkPorps {
+  $fontSize?: number;
+  $isFilled?: boolean;
+  $isTransition?: boolean;
 }
 
-export interface StyledLinkProps {
-  backgroundColor: string;
-  borderColor: string;
-  transition: boolean;
-  color: string;
-  fontSize: string;
+export interface SquareLinkProps extends StyledLinkPorps {
+  link: string;
+  children: string;
 }
 
 function SquareLink({
   link,
-  width,
-  height,
+  $fontSize,
+  $isFilled,
+  $isTransition,
   children,
-  backgroundColor,
-  color,
-  borderColor,
-  transition,
-  fontSize,
 }: SquareLinkProps) {
   return (
-    <>
-      <Link to={link}>
-        <StyledLink
-          style={{ width, height }}
-          backgroundColor={backgroundColor}
-          color={color}
-          borderColor={borderColor}
-          transition={transition}
-          fontSize={fontSize}
-        >
-          {children}
-        </StyledLink>
-      </Link>
-    </>
+    <StyledLink
+      to={link}
+      $fontSize={$fontSize}
+      $isFilled={$isFilled}
+      $isTransition={$isTransition}
+    >
+      {children}
+    </StyledLink>
   );
 }
 
-SquareLink.defaultProps = {
-  height: 40,
-  backgroundColor: 'var(--purple-900)',
-  color: 'var(--white)',
-  borderColor: 'var(--purple-900)',
-  transition: false,
-  fontSize: 'var(--text-md)',
-};
-
-export const StyledLink = styled.div<StyledLinkProps>`
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  justify-content: center;
-  background-color: ${({ backgroundColor }) => backgroundColor};
-  color: ${({ color }) => color};
-  border: 1px solid ${({ borderColor }) => borderColor};
-  border-radius: 0.3125rem;
-  text-decoration: none;
-  font-weight: 700;
-  font-size: ${({ fontSize }) => fontSize};
-
-  ${({ transition, backgroundColor, color }) => {
-    return transition
-      ? /*css*/ `
+const LINK_STYLE = Object.freeze({
+  isFilled: css`
+    background-color: var(--purple-900);
+    border: none;
+    color: var(--white);
+  `,
+  isNotFilled: css`
+    background-color: var(--white);
+    border: 1px solid var(--purple-900);
+    color: var(--purple-900);
+  `,
+  isTransition: css`
     &:hover,
     &:focus {
-    transition: color 0.3s ease-out, background-color 0.3s ease-out;
-    color: ${backgroundColor};
-    background-color: ${color};
-  }`
-      : null;
-  }}
+      color: var(--white);
+      background-color: var(--purple-900);
+      transition: color 0.3s ease-out, background-color 0.3s ease-out;
+    }
+  `,
+});
+
+export const StyledLink = styled(Link)<StyledLinkPorps>`
+  ${({ $isFilled }) =>
+    $isFilled ? LINK_STYLE.isFilled : LINK_STYLE.isNotFilled}
+  width: fit-content;
+  padding: ${({ $fontSize }) =>
+    `${($fontSize as number) * 0.35}px ${($fontSize as number) * 0.8}px`};
+  border-radius: 0.3125rem;
+  font-size: ${({ $fontSize }) => $fontSize}px;
+  font-weight: 700;
+  text-align: center;
+  text-decoration: none;
+
+  ${({ $isTransition }) => ($isTransition ? LINK_STYLE.isTransition : null)};
 
   &:focus {
     cursor: pointer;
@@ -86,5 +73,11 @@ export const StyledLink = styled.div<StyledLinkProps>`
     outline-offset: 0.2em;
   }
 `;
+
+SquareLink.defaultProps = Object.freeze({
+  $fontSize: 20,
+  $isFilled: true,
+  $isTransition: false,
+});
 
 export default memo(SquareLink);


### PR DESCRIPTION
## PR Type
- [ ] FEAT: 새로운 기능 구현
- [x] FIX: 버그 수정
- [ ] DOCS: 문서 추가 및 수정
- [ ] STYLE: 포맷팅 변경
- [x] REFACTOR: 코드 리팩토링
- [ ] TEST: 테스트 관련
- [ ] DEPLOY: 배포 관련
- [x] CHORE: 빌드, 환경 설정 등 기타 작업

## Abstracts
* LogoLink, SquareButton, SquareLink 컴포넌트를 리팩토링하고 리팩토링 결과에 따라 각 컴포넌트의 StoryBook을 재작성합니다.

## Description
### 작업 내용
#### preview.jsx 파일의 import 경로 수정

#### LogoLink 컴포넌트 리팩토링
- 이미지 경로 상수로 분리
- aria-label과 alt text의 역할 중복 해결
- import 문 순서 변경

#### LogoLink 컴포넌트 StoryBook 재작성
- 기존 small, large로 구분하는 Story를 사용처에 따라 Header, SignInAndUp, NotFound로 변경
- docs 탭에 컴포넌트, props 설명 추가

#### SquareButton 컴포넌트 리팩토링
- 객체 불변성 지향
- mixin 사용하여 가독성 향상
- width 속성 추가

#### SquareButton 컴포넌트 StoryBook 재작성
- docs 탭에 컴포넌트, props 설명, default props 추가

#### SquareLink 컴포넌트 리팩토링
- import 문 순서 변경
- 객체 불변성 지향
- mixin 사용하여 가독성 향상
- 불필요한 props 정리 및 최소화

#### SquareLink 컴포넌트 StoryBook 재작성
- 기존 style로 구분하는 Story를 사용처에 따라 MyCollections, SignIn으로 변경
- docs 탭에 컴포넌트, props 설명, default props 추가

#### Header 컴포넌트 리팩토링
- SquareLink 컴포넌트의 변경 사항만 적용

## Discussion
* 몇몇 파일에서 `'React' refers to a UMD global, but the current file is a module` 에러 발생
  * [참조 링크](https://donghyun-dev.tistory.com/136)
  * 저번 리팩토링 때 뭘 잘못 건드렸는지 모르겠지만 import 문에 React를 수동으로 import 하면 에러가 해결됨, 그러나 이는 임시적인 해결 방안이므로 따로 방법을 찾아볼 필요가 있음
* SquareButton과 SquareLink 컴포넌트 관련 논의 필요
  * 스타일링적인 자유도를 얼마나 부여할지 논의가 필요합니다. 현재 SquareButton 컴포넌트의 경우 크기를 `size` prop의 값인 `small`, `large` 두 가지로만 지정할 수 있지만, SquareLink 컴포넌트는 `fontSize` prop에 따라 크기가 유동적으로 변하는 구조이므로 이를 통일할 필요가 있을 듯합니다.

---
Close #183 
