### PR TITLE
Alert, PageTitle, TextInput, LPCover, SearchResultText, VinylItem, VinylItems 컴포넌트 리팩토링

### DIFF
--- a/src/components/features/DetailInfo/DetailInfo.stories.tsx
+++ b/src/components/features/DetailInfo/DetailInfo.stories.tsx
@@ -19,16 +19,22 @@ export const Released = Template.bind({});
 Released.args = {
   infoName: 'Released',
   infoContent: 'Aug 2014',
+  isValid: true,
+  isMyItem: false,
 };
 
 export const Genre = Template.bind({});
 Genre.args = {
   infoName: 'Genre',
   infoContent: 'Pop, Folk, World, & Country',
+  isValid: true,
+  isMyItem: false,
 };
 
 export const Style = Template.bind({});
-Genre.args = {
-  infoName: 'Genre',
-  infoContent: 'Pop, Folk, World, & Country',
+Style.args = {
+  infoName: 'Style',
+  infoContent: 'Folk, Ballad, K-pop',
+  isValid: true,
+  isMyItem: false,
 };

--- a/src/components/features/DetailInfo/DetailInfo.tsx
+++ b/src/components/features/DetailInfo/DetailInfo.tsx
@@ -49,7 +49,7 @@ function DetailInfo({
       ) : (
         <InfoContent>
           {isMyItem && <span aria-hidden={true}>{' ㆍ '}</span>}
-          {infoString}
+          <span>{infoString}</span>
         </InfoContent>
       )}
     </>

--- a/src/components/features/LPCover/LPCover.stories.tsx
+++ b/src/components/features/LPCover/LPCover.stories.tsx
@@ -1,11 +1,11 @@
 // import React from 'react';
 import { ComponentStory, ComponentMeta } from '@storybook/react';
-import { mockSearchResult_default } from '@/utils/mocks/mockInfo';
 import LPCover from './LPCover';
+import { mockSearchResult_default } from '@/utils/mocks/mockInfo';
 import { ProcessedResult } from '@/types/data';
 
 export default {
-  title: 'common/components/LPCover',
+  title: 'features/LPCover',
   component: LPCover,
   parameters: {
     design: {
@@ -18,8 +18,8 @@ const Template: ComponentStory<typeof LPCover> = (args) => (
   <LPCover {...args} />
 );
 
-export const SmallWithHoverEvnet = Template.bind({});
-SmallWithHoverEvnet.args = {
+export const SmallWithHoverEvent = Template.bind({});
+SmallWithHoverEvent.args = {
   searchResult: mockSearchResult_default as ProcessedResult,
   size: 'small',
   hoverInteraction: true,
@@ -39,11 +39,32 @@ ImgUrlIsEmptyString.args = {
   hoverInteraction: true,
 };
 
+export const ImgUrlIsEmptyStringAndTitleIsLong = Template.bind({});
+ImgUrlIsEmptyStringAndTitleIsLong.args = {
+  searchResult: {
+    ...mockSearchResult_default,
+    imgUrl: '',
+    titleInfo: { title: '꽃갈피꽃갈피꽃갈피꽃갈피꽃갈피', artist: 'IU' },
+  } as ProcessedResult,
+  size: 'small',
+  hoverInteraction: true,
+};
+
 export const ImgUrlIsInvalid = Template.bind({});
 ImgUrlIsInvalid.args = {
   searchResult: {
     ...mockSearchResult_default,
     imgUrl: 'asdfasdf',
+  } as ProcessedResult,
+  size: 'small',
+  hoverInteraction: true,
+};
+
+export const ImgUrlIsUndefined = Template.bind({});
+ImgUrlIsUndefined.args = {
+  searchResult: {
+    ...mockSearchResult_default,
+    imgUrl: undefined,
   } as ProcessedResult,
   size: 'small',
   hoverInteraction: true,

--- a/src/components/features/LPCover/LPCover.tsx
+++ b/src/components/features/LPCover/LPCover.tsx
@@ -1,12 +1,10 @@
+import { useMemo, memo } from 'react';
 import { Link } from 'react-router-dom';
 import styled from 'styled-components';
+import { absolute } from '@/styles/mixin';
 import { ProcessedResult } from '@/types/data';
-import { useMemo, memo } from 'react';
 
-const HEIGHT_PX = {
-  small: 150,
-  large: 394,
-};
+const HEIGHT_PX = { small: 150, large: 394 };
 
 export interface LPCoverProps {
   searchResult: ProcessedResult;
@@ -20,61 +18,60 @@ export interface HeightProps {
 
 function LPCover({
   searchResult,
-  size,
-  hoverInteraction,
-  ...props
+  size = 'small',
+  hoverInteraction = true,
 }: LPCoverProps) {
-  const heightNum = HEIGHT_PX[size as 'small' | 'large'];
-  const { id, titleInfo, imgUrl } = searchResult;
+  const { id, titleInfo, imgUrl = '' } = searchResult;
+  const heightNum = HEIGHT_PX[size];
 
   return useMemo(
     () => (
-      <Wrapper
+      // TODO: Items 페이지에서는 Link로 작동하면 안됨
+      <StyledLink
         to={`/item/${id}`}
         state={searchResult}
         $heightNum={heightNum}
-        style={{
-          width: heightNum,
-          height: heightNum,
-        }}
-        {...props}
+        aria-label={titleInfo.title}
       >
         <Cover
           src={imgUrl}
           alt=""
           data-title={titleInfo.title}
-          $heightNum={heightNum}
           width={heightNum}
           height={heightNum}
+          $heightNum={heightNum}
+          draggable={false}
         />
         {hoverInteraction && (
           <Vinyl
             className="vinyl"
             src="/assets/vinyl.svg"
             alt=""
-            style={{ width: heightNum, height: heightNum }}
+            width={heightNum}
+            height={heightNum}
+            draggable={false}
           />
         )}
-      </Wrapper>
+      </StyledLink>
     ),
     [searchResult, size, hoverInteraction]
   );
 }
 
-LPCover.defaultProps = {
-  size: 'small',
-  hoverInteraction: true,
-};
-
-const Wrapper = styled(Link)<HeightProps>`
+const StyledLink = styled(Link)<HeightProps>`
+  display: block;
   position: relative;
+  width: ${({ $heightNum }) => $heightNum}px;
+  height: ${({ $heightNum }) => $heightNum}px;
 
   &:hover .vinyl {
-    left: ${({ $heightNum }) => $heightNum / 3}px;
+    transform: translate3d(${({ $heightNum }) => $heightNum / 3}px, 0, 0);
   }
 `;
 
 const Cover = styled.img<HeightProps>`
+  position: absolute;
+  object-fit: cover;
   box-shadow: var(--shadow-Item);
   background-color: var(--gray-100);
 
@@ -95,31 +92,23 @@ const Cover = styled.img<HeightProps>`
   // img가 제대로 불러와지지 않았을 때 보일 가상 요소
   &::before {
     content: attr(data-title);
-    position: absolute;
-    top: 0;
-    right: 0;
-    bottom: 0;
-    left: 0;
-    width: 100%;
-    height: 100%;
+    ${absolute({ t: 0, r: 0, b: 0, l: 0 })};
+    width: ${({ $heightNum }) => $heightNum}px;
+    height: ${({ $heightNum }) => $heightNum}px;
+    padding: 10px;
+    line-height: ${({ $heightNum }) => $heightNum - 20}px;
     text-align: center;
-    line-height: ${({ $heightNum }) => $heightNum}px;
     background-color: var(--gray-100);
     box-shadow: var(--shadow-Item);
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;
-    text-indent: 12px;
     word-break: break-all;
   }
 `;
 
 const Vinyl = styled.img`
-  position: absolute;
-  top: 0;
-  right: 0;
-  bottom: 0;
-  left: 0;
+  ${absolute({ t: 0, r: 0, b: 0, l: 0 })};
   transition: all 0.3s ease;
   z-index: -100;
   // TODO: box-shadow 방식과 shadow 형태가 살짝 다름

--- a/src/components/features/SearchResultText/SearchResultText.stories.tsx
+++ b/src/components/features/SearchResultText/SearchResultText.stories.tsx
@@ -2,7 +2,7 @@ import { ComponentMeta, ComponentStory } from '@storybook/react';
 import SearchResultText from './SearchResultText';
 
 export default {
-  title: 'common/components/SearchResultText',
+  title: 'features/SearchResultText',
   component: SearchResultText,
   args: {
     resultCount: 0,
@@ -26,11 +26,29 @@ const Template: ComponentStory<typeof SearchResultText> = (args) => (
   <SearchResultText {...args} />
 );
 
-export const Example = Template.bind({});
-Example.story = {
+export const QueryFromSearchParams = Template.bind({});
+QueryFromSearchParams.story = {
   parameters: {
     reactRouter: {
       searchParams: { query: 'IU' },
     },
   },
+};
+
+export const QueryFromProps = Template.bind({});
+QueryFromProps.args = {
+  searchWord: '아이유',
+};
+
+export const QueryIsEmptyString = Template.bind({});
+QueryIsEmptyString.args = {
+  searchWord: '',
+};
+
+export const QueryIsUndefined = Template.bind({});
+QueryIsUndefined.args = {};
+
+export const QueryIsLong = Template.bind({});
+QueryIsLong.args = {
+  searchWord: 'ABCDEFGHIJKLMNOPQRSTUVWXYZ',
 };

--- a/src/components/features/SearchResultText/SearchResultText.tsx
+++ b/src/components/features/SearchResultText/SearchResultText.tsx
@@ -1,52 +1,50 @@
-import styled, { css } from 'styled-components';
-import { useSearchParams } from 'react-router-dom';
 import { useMemo } from 'react';
+import { useSearchParams } from 'react-router-dom';
+import styled from 'styled-components';
 
 export interface SearchResultTextProps {
   resultCount: number;
   searchWord?: string;
 }
 
-function SearchResultText({
-  resultCount,
-  searchWord,
-  ...props
-}: SearchResultTextProps) {
+function SearchResultText({ resultCount, searchWord }: SearchResultTextProps) {
   const [searchParams] = useSearchParams();
+  const query = searchWord || searchParams.get('query') || '';
+  const formattedQuery =
+    '"' + (query.length > 20 ? query.substring(0, 20) + '… ' : query) + '"';
+
   return useMemo(
     () => (
-      <SearchResultTextWrapper {...props}>
-        <KeyWord>{`"${searchWord ?? searchParams.get('query')}"`}</KeyWord>
-        <ResultInfo>{`검색 결과  ${resultCount} 건`}</ResultInfo>
+      <SearchResultTextWrapper>
+        {/* TODO: 임시방편으로 이렇게 구현해두긴 했지만..
+        빈 문자열이 검색되었을 경우 허수 검색결과가 많아서 아예 다른 뷰를 보여주는 게 나을듯.. */}
+        {query ? (
+          <>
+            <PurpleText>{formattedQuery}</PurpleText>
+            <NormalText>
+              &nbsp;&nbsp;검색 결과&nbsp;&nbsp;{resultCount} 건
+            </NormalText>
+          </>
+        ) : (
+          <NormalText>전체 LP&nbsp;&nbsp;{resultCount} 건</NormalText>
+        )}
       </SearchResultTextWrapper>
     ),
-    [resultCount, searchWord]
+    [resultCount, query]
   );
 }
 
-const fontStyle = css`
+const SearchResultTextWrapper = styled.span`
   font-weight: 700;
   font-size: var(--text-md);
-`;
-
-const SearchResultTextWrapper = styled.div`
-  display: flex;
-  flex-flow: row nowrap;
-  gap: var(--space-xs);
-  max-width: 408px;
-`;
-
-const KeyWord = styled.span`
-  ${fontStyle};
-  color: var(--purple-900);
-  max-width: 284px;
-  overflow: hidden;
   white-space: nowrap;
-  text-overflow: ellipsis;
 `;
 
-const ResultInfo = styled.span`
-  ${fontStyle};
+const PurpleText = styled.span`
+  color: var(--purple-900);
+`;
+
+const NormalText = styled.span`
   color: var(--black);
 `;
 

--- a/src/components/features/SearchResultText/SearchResultText.tsx
+++ b/src/components/features/SearchResultText/SearchResultText.tsx
@@ -9,18 +9,18 @@ export interface SearchResultTextProps {
 
 function SearchResultText({ resultCount, searchWord }: SearchResultTextProps) {
   const [searchParams] = useSearchParams();
-  const query = searchWord || searchParams.get('query') || '';
-  const formattedQuery =
-    '"' + (query.length > 20 ? query.substring(0, 20) + '… ' : query) + '"';
+  const queryString = searchWord || searchParams.get('query') || '';
+  const formattedQueryString =
+    '"' + (queryString.length > 20 ? queryString.substring(0, 20) + '… ' : queryString) + '"';
 
   return useMemo(
     () => (
       <SearchResultTextWrapper>
         {/* TODO: 임시방편으로 이렇게 구현해두긴 했지만..
         빈 문자열이 검색되었을 경우 허수 검색결과가 많아서 아예 다른 뷰를 보여주는 게 나을듯.. */}
-        {query ? (
+        {queryString ? (
           <>
-            <PurpleText>{formattedQuery}</PurpleText>
+            <PurpleText>{formattedQueryString}</PurpleText>
             <NormalText>
               &nbsp;&nbsp;검색 결과&nbsp;&nbsp;{resultCount} 건
             </NormalText>
@@ -30,7 +30,7 @@ function SearchResultText({ resultCount, searchWord }: SearchResultTextProps) {
         )}
       </SearchResultTextWrapper>
     ),
-    [resultCount, query]
+    [resultCount, queryString]
   );
 }
 

--- a/src/components/features/SelectCollectionForm/ToggleInputButton.tsx
+++ b/src/components/features/SelectCollectionForm/ToggleInputButton.tsx
@@ -7,6 +7,7 @@ function ToggleInputButton() {
   const [isClicked, setIsClicked] = useState(false);
   const [dialogContent, setDialogContent] = useRecoilState(dialogContentState);
 
+  // TODO: errorMsg가 표시되는 동안에는 Enter 입력 그냥 Return 처리
   const handleKeyUp: ComponentProps<'input'>['onKeyDown'] = (e) => {
     e.stopPropagation();
 
@@ -33,8 +34,8 @@ function ToggleInputButton() {
     <>
       {isClicked ? (
         <TextInput
-          width={432}
-          height={48}
+          $width={432}
+          $height={48}
           placeholder="생성할 콜렉션의 이름을 입력해주세요."
           required={true}
           validationTester={/^.{1,}$/}

--- a/src/components/features/VinylItem/VinylItem.stories.tsx
+++ b/src/components/features/VinylItem/VinylItem.stories.tsx
@@ -1,9 +1,10 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
-import { mockSearchResult_default } from '@/utils/mocks/mockInfo';
 import VinylItem from './VinylItem';
+import { mockSearchResult_default } from '@/utils/mocks/mockInfo';
 
+// TODO: 스토리북 새로고침 해야만 보이는 에러 해결(Album Info 컴포넌트 확인 필요)
 export default {
-  title: 'common/components/VinylItem',
+  title: 'features/VinylItem',
   component: VinylItem,
   args: {
     searchResult: mockSearchResult_default,

--- a/src/components/features/VinylItem/VinylItem.tsx
+++ b/src/components/features/VinylItem/VinylItem.tsx
@@ -1,21 +1,18 @@
 import { useMemo, memo } from 'react';
+import { LPCover, AlbumInfo } from '@/components';
 import styled, { css } from 'styled-components';
-import { AlbumInfo, LPCover } from '@/components';
+import { flexContainer } from '@/styles/mixin';
 import { ProcessedResult } from '@/types/data';
 import { PageProps, ViewProps } from '@/types/render';
 
-export interface VinylItemProps extends ViewProps, PageProps {
+export interface VinylItemProps extends PageProps, ViewProps {
   searchResult: ProcessedResult;
   [props: string]: unknown;
 }
 
 function VinylItem({ searchResult, page, view, ...props }: VinylItemProps) {
-  const vinylSize = useMemo(
-    () => (view === 'detail' ? 'large' : 'small'),
-    [view]
-  );
-
-  const isHover = useMemo(() => view !== 'detail', [view]);
+  const vinylSize = view === 'detail' ? 'large' : 'small';
+  const hasHoverInteraction = view !== 'detail';
 
   return useMemo(
     () => (
@@ -23,7 +20,7 @@ function VinylItem({ searchResult, page, view, ...props }: VinylItemProps) {
         <LPCover
           searchResult={searchResult}
           size={vinylSize}
-          hoverInteraction={isHover}
+          hoverInteraction={hasHoverInteraction}
         />
         <AlbumInfo searchResult={searchResult} page={page} view={view} />
       </VinylItemWrapper>
@@ -34,20 +31,15 @@ function VinylItem({ searchResult, page, view, ...props }: VinylItemProps) {
 
 const WRAPPER_STYLE = {
   block: css`
-    display: flex;
-    flex-flow: column wrap;
+    ${flexContainer({ d: 'column', w: 'wrap' })};
     width: 150px;
   `,
   list: css`
-    display: flex;
-    flex-flow: row nowrap;
-    justify-content: center;
-    gap: 60px;
+    ${flexContainer({ d: 'row', w: 'nowrap', jc: 'center', g: '60px' })};
     min-width: 680px;
   `,
   detail: css`
-    display: flex;
-    flex-flow: column wrap;
+    ${flexContainer({ d: 'column', w: 'wrap' })};
     width: 394px;
   `,
   myitem: css``,

--- a/src/components/features/VinylItem/VinylItem.tsx
+++ b/src/components/features/VinylItem/VinylItem.tsx
@@ -12,7 +12,6 @@ export interface VinylItemProps extends PageProps, ViewProps {
 
 function VinylItem({ searchResult, page, view, ...props }: VinylItemProps) {
   const vinylSize = view === 'detail' ? 'large' : 'small';
-  const hasHoverInteraction = view !== 'detail';
 
   return useMemo(
     () => (
@@ -20,7 +19,7 @@ function VinylItem({ searchResult, page, view, ...props }: VinylItemProps) {
         <LPCover
           searchResult={searchResult}
           size={vinylSize}
-          hoverInteraction={hasHoverInteraction}
+          hoverInteraction={view !== 'detail'}
         />
         <AlbumInfo searchResult={searchResult} page={page} view={view} />
       </VinylItemWrapper>

--- a/src/components/features/VinylItems/VinylItems.stories.tsx
+++ b/src/components/features/VinylItems/VinylItems.stories.tsx
@@ -1,9 +1,10 @@
 import type { ComponentMeta, ComponentStory } from '@storybook/react';
-import { mockSearchResults } from '@/utils/mocks/mockInfo';
 import VinylItems from './VinylItems';
+import { mockSearchResults } from '@/utils/mocks/mockInfo';
 
+// TODO: 스토리북 새로고침 해야만 보이는 에러 해결(Album Info 컴포넌트 확인 필요)
 export default {
-  title: 'common/components/VinylItems',
+  title: 'features/VinylItems',
   component: VinylItems,
   args: {
     searchResults: mockSearchResults,
@@ -11,7 +12,7 @@ export default {
 } as ComponentMeta<typeof VinylItems>;
 
 const Template: ComponentStory<typeof VinylItems> = (args) => (
-  <VinylItems {...args}></VinylItems>
+  <VinylItems {...args} />
 );
 
 export const AllBlock = Template.bind({});
@@ -32,7 +33,7 @@ AllList.args = {
 };
 AllList.parameters = {
   design: {
-    url: 'https://www.figma.com/file/y5dq4m439YJKRTrKw5ZsZV/33-1%2F3?node-id=133%3A344&t=klXldng2oaYkGL1Z-4',
+    url: 'https://www.figma.com/file/y5dq4m439YJKRTrKw5ZsZV/33-1%2F3?node-id=181%3A622&t=WViOsk1J5WsWdz9q-4',
   },
 };
 
@@ -43,7 +44,7 @@ CollectionBlock.args = {
 };
 CollectionBlock.parameters = {
   design: {
-    url: 'https://www.figma.com/file/y5dq4m439YJKRTrKw5ZsZV/33-1%2F3?node-id=133%3A344&t=klXldng2oaYkGL1Z-4',
+    url: 'https://www.figma.com/file/y5dq4m439YJKRTrKw5ZsZV/33-1%2F3?node-id=181%3A3054&t=WViOsk1J5WsWdz9q-4',
   },
 };
 
@@ -54,6 +55,6 @@ CollectionList.args = {
 };
 CollectionList.parameters = {
   design: {
-    url: 'https://www.figma.com/file/y5dq4m439YJKRTrKw5ZsZV/33-1%2F3?node-id=133%3A344&t=klXldng2oaYkGL1Z-4',
+    url: 'https://www.figma.com/file/y5dq4m439YJKRTrKw5ZsZV/33-1%2F3?node-id=181%3A4470&t=WViOsk1J5WsWdz9q-4',
   },
 };

--- a/src/components/features/VinylItems/VinylItems.tsx
+++ b/src/components/features/VinylItems/VinylItems.tsx
@@ -13,16 +13,19 @@ export interface VinylItemsProps extends ViewProps, PageProps {
 function VinylItems({ searchResult, page, view, ...props }: VinylItemsProps) {
   return (
     <VinylItemsWrapper view={view} {...props}>
-      {searchResult.map((result) => (
-        <VinylItem
-          key={uuid()}
-          searchResult={result}
-          page={page}
-          view={view}
-          data-releasedid={getId(result.resourceUrl)}
-          className="infoContainer"
-        />
-      ))}
+      {searchResult.map((result) => {
+        const releasedId = getId(result.resourceUrl);
+        return (
+          <VinylItem
+            key={releasedId}
+            searchResult={result}
+            page={page}
+            view={view}
+            data-releasedid={releasedId}
+            className="infoContainer"
+          />
+        );
+      })}
     </VinylItemsWrapper>
   );
 }

--- a/src/components/features/VinylItems/VinylItems.tsx
+++ b/src/components/features/VinylItems/VinylItems.tsx
@@ -1,19 +1,20 @@
 import { memo } from 'react';
-import uuid from 'react-uuid';
-import styled, { css } from 'styled-components';
 import { VinylItem } from '@/components';
+import styled, { css } from 'styled-components';
+import { flexContainer } from '@/styles/mixin';
 import { getId } from '@/utils/functions/processResult';
 import { ProcessedResult } from '@/types/data';
-import { ViewProps, PageProps } from '@/types/render';
+import { PageProps, ViewProps } from '@/types/render';
 
-export interface VinylItemsProps extends ViewProps, PageProps {
-  searchResult: ProcessedResult[];
+export interface VinylItemsProps extends PageProps, ViewProps {
+  searchResults: ProcessedResult[];
+  [props: string]: unknown;
 }
 
-function VinylItems({ searchResult, page, view, ...props }: VinylItemsProps) {
+function VinylItems({ searchResults, page, view, ...props }: VinylItemsProps) {
   return (
     <VinylItemsWrapper view={view} {...props}>
-      {searchResult.map((result) => {
+      {searchResults.map((result) => {
         const releasedId = getId(result.resourceUrl);
         return (
           <VinylItem
@@ -42,22 +43,19 @@ const WRAPPER_STYLE = {
     }
   `,
   list: css`
-    flex-flow: column wrap;
-    justify-content: center;
+    ${flexContainer({ d: 'column', w: 'wrap', jc: 'center' })}
     row-gap: 60px;
   `,
-  detail: css`
-    display: none;
-  `,
+  detail: css``,
   myitem: css``,
 };
 
 const VinylItemsWrapper = styled.section<ViewProps>`
-  display: flex;
+  ${flexContainer({})}
+  // TODO: 반응형을 위한 min&max width 처리는 main 컴포넌트에서 해야 함
   min-width: 680px;
   max-width: 828px;
-  margin: 0 auto;
-  margin-top: 52px;
+  margin: 52px auto 0;
   ${({ view }) => WRAPPER_STYLE[view]};
 `;
 

--- a/src/components/layout/InquiryButton/InquiryButton.tsx
+++ b/src/components/layout/InquiryButton/InquiryButton.tsx
@@ -119,7 +119,7 @@ function InquiryButton({
         )}
       </AnimatePresence>
       {showAlert && (
-        <Alert type="bottomRight" width="200px">
+        <Alert $type="bottomRight" $width="200px">
           감사합니다 : )
         </Alert>
       )}

--- a/src/components/shared/Alert/Alert.stories.tsx
+++ b/src/components/shared/Alert/Alert.stories.tsx
@@ -10,35 +10,35 @@ const Template: ComponentStory<typeof Alert> = (args) => <Alert {...args} />;
 
 export const TopAlert = Template.bind({});
 TopAlert.args = {
-  type: 'top',
+  $type: 'top',
   children: 'TopAlert',
 };
 
 export const LongTopAlert = Template.bind({});
 LongTopAlert.args = {
-  type: 'top',
+  $type: 'top',
   children:
     'LongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlertLongTopAlert',
 };
 
 export const TopAlertWithFixedWidth = Template.bind({});
 TopAlertWithFixedWidth.args = {
-  type: 'top',
-  width: '300px',
+  $type: 'top',
+  $width: '300px',
   children: 'TopAlertWithFixedWidth',
 };
 
 export const BottomRightAlert = Template.bind({});
 BottomRightAlert.args = {
-  type: 'bottomRight',
-  width: '300px',
+  $type: 'bottomRight',
+  $width: '300px',
   children: 'BottomRightAlert',
 };
 
 export const LongBottomRightAlert = Template.bind({});
 LongBottomRightAlert.args = {
-  type: 'bottomRight',
-  width: '300px',
+  $type: 'bottomRight',
+  $width: '300px',
   children:
     'LongBottomRightAlertLongBottomRightAlertLongBottomRightAlertLongBottomRightAlertLongBottomRightAlertLongBottomRightAlertLongBottomRightAlert',
 };

--- a/src/components/shared/Alert/Alert.tsx
+++ b/src/components/shared/Alert/Alert.tsx
@@ -1,6 +1,6 @@
 import styled, { css } from 'styled-components';
 import { flexContainer } from '@/styles/mixin';
-import widthHeightToPx from '@/utils/functions/widthHeightToPx';
+import lengthToPxStr from '@/utils/functions/lengthToPxStr';
 
 export interface AlertProps {
   $type: 'top' | 'bottomRight';
@@ -73,7 +73,7 @@ const StyledAlert = styled.div<AlertProps>`
   ${flexContainer({ jc: 'center', ai: 'center' })}
   padding: 20px;
   /* TODO: default props 타입 단언 말고 다른 방법은? */
-  width: ${({ $width }) => widthHeightToPx($width as number | string)};
+  width: ${({ $width }) => lengthToPxStr($width as number | string)};
   height: fit-content;
   color: ${({ textColor }) => textColor};
   background-color: ${({ backgroundColor }) => backgroundColor};

--- a/src/components/shared/Alert/Alert.tsx
+++ b/src/components/shared/Alert/Alert.tsx
@@ -1,25 +1,27 @@
 import styled, { css } from 'styled-components';
+import { flexContainer } from '@/styles/mixin';
+import widthHeightToPx from '@/utils/functions/widthHeightToPx';
 
 export interface AlertProps {
-  type: 'top' | 'bottomRight';
-  width?: string | number;
+  $type: 'top' | 'bottomRight';
+  $width?: string | number;
   textColor?: string;
   backgroundColor?: string;
   children: string;
 }
 
 function Alert({
-  type,
-  width,
-  textColor,
-  backgroundColor,
+  $type,
+  $width = '100vw',
+  textColor = 'var(--purple-900)',
+  backgroundColor = 'var(--purple-100)',
   children,
 }: AlertProps) {
   return (
     <StyledAlert
-      type={type}
       role="alert"
-      style={{ width }}
+      $type={$type}
+      $width={$width}
       textColor={textColor}
       backgroundColor={backgroundColor}
     >
@@ -27,12 +29,6 @@ function Alert({
     </StyledAlert>
   );
 }
-
-Alert.defaultProps = {
-  width: '100vw',
-  textColor: 'var(--purple-900)',
-  backgroundColor: 'var(--purple-100)',
-};
 
 const ALERT_STYLE = {
   top: css`
@@ -74,18 +70,18 @@ const ALERT_STYLE = {
 
 const StyledAlert = styled.div<AlertProps>`
   position: fixed;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  ${flexContainer({ jc: 'center', ai: 'center' })}
   padding: 20px;
+  /* TODO: default props 타입 단언 말고 다른 방법은? */
+  width: ${({ $width }) => widthHeightToPx($width as number | string)};
   height: fit-content;
   color: ${({ textColor }) => textColor};
   background-color: ${({ backgroundColor }) => backgroundColor};
   word-break: break-all;
   z-index: 3000;
 
-  ${({ type }) => ALERT_STYLE[type]}
-  animation: ${({ type }) => `${type} 3s both`};
+  ${({ $type }) => ALERT_STYLE[$type]}
+  animation: ${({ $type }) => `${$type} 3s both`};
 
   &:empty {
     display: none;

--- a/src/components/shared/IconButton/IconButton.tsx
+++ b/src/components/shared/IconButton/IconButton.tsx
@@ -36,18 +36,16 @@ function IconButton({
   const IconComponent = ICONS[iconType];
 
   return (
-    <>
-      <IconButtonContainer
-        type="button"
-        style={{ width, height }}
-        $color={color}
-        backgroundColor={backgroundColor}
-        onClick={clickHandler}
-        {...props}
-      >
-        <IconComponent width={width} height={height} />
-      </IconButtonContainer>
-    </>
+    <IconButtonContainer
+      type="button"
+      style={{ width, height }}
+      $color={color}
+      backgroundColor={backgroundColor}
+      onClick={clickHandler}
+      {...props}
+    >
+      <IconComponent width={width} height={height} />
+    </IconButtonContainer>
   );
 }
 

--- a/src/components/shared/PageTitle/PageTitle.tsx
+++ b/src/components/shared/PageTitle/PageTitle.tsx
@@ -1,8 +1,9 @@
 import styled from 'styled-components';
+import lengthToPxStr from '@/utils/functions/lengthToPxStr';
 
 export interface PageTitleProps {
-  marginTop?: string;
-  marginBottom?: string;
+  marginTop?: number | string;
+  marginBottom?: number | string;
   children: string;
 }
 
@@ -19,8 +20,11 @@ function PageTitle({
 }
 
 const StyledH2 = styled.h2<PageTitleProps>`
+  /* TODO: default props 타입 단언 말고 다른 방법은? */
   margin: ${({ marginTop, marginBottom }) =>
-    `${marginTop} auto ${marginBottom}`};
+    `${lengthToPxStr(marginTop as number | string)} auto ${lengthToPxStr(
+      marginBottom as number | string
+    )}`};
   min-width: 680px;
   max-width: 828px;
   font-size: 40px;

--- a/src/components/shared/PageTitle/PageTitle.tsx
+++ b/src/components/shared/PageTitle/PageTitle.tsx
@@ -6,20 +6,19 @@ export interface PageTitleProps {
   children: string;
 }
 
-function PageTitle({ marginTop, marginBottom, children }: PageTitleProps) {
+function PageTitle({
+  marginTop = '0px',
+  marginBottom = '0px',
+  children,
+}: PageTitleProps) {
   return (
-    <H2 marginTop={marginTop} marginBottom={marginBottom}>
+    <StyledH2 marginTop={marginTop} marginBottom={marginBottom}>
       {children}
-    </H2>
+    </StyledH2>
   );
 }
 
-PageTitle.defaultProps = {
-  marginTop: '0px',
-  marginBottom: '0px',
-};
-
-const H2 = styled.h2<PageTitleProps>`
+const StyledH2 = styled.h2<PageTitleProps>`
   margin: ${({ marginTop, marginBottom }) =>
     `${marginTop} auto ${marginBottom}`};
   min-width: 680px;

--- a/src/components/shared/TextInput/TextInput.stories.tsx
+++ b/src/components/shared/TextInput/TextInput.stories.tsx
@@ -17,8 +17,8 @@ const Template: ComponentStory<typeof TextInput> = (args) => (
 
 export const TextInputWithLabel = Template.bind({});
 TextInputWithLabel.args = {
-  width: 416,
-  height: 36,
+  $width: 416,
+  $height: 36,
   label: 'Label',
   placeholder: 'placeholder',
   required: true,
@@ -28,8 +28,8 @@ TextInputWithLabel.args = {
 
 export const TextInputWithoutLabel = Template.bind({});
 TextInputWithoutLabel.args = {
-  width: 416,
-  height: 36,
+  $width: 416,
+  $height: 36,
   placeholder: 'placeholder',
   required: true,
   validationTester: /^.{1,}$/,
@@ -38,8 +38,8 @@ TextInputWithoutLabel.args = {
 
 export const TextInputWithoutPlaceholder = Template.bind({});
 TextInputWithoutPlaceholder.args = {
-  width: 416,
-  height: 36,
+  $width: 416,
+  $height: 36,
   label: 'Label',
   required: true,
   validationTester: /^.{1,}$/,
@@ -48,8 +48,8 @@ TextInputWithoutPlaceholder.args = {
 
 export const TextInputWithInitialValue = Template.bind({});
 TextInputWithInitialValue.args = {
-  width: 416,
-  height: 36,
+  $width: 416,
+  $height: 36,
   label: 'Label',
   placeholder: 'placeholder',
   required: true,
@@ -60,12 +60,11 @@ TextInputWithInitialValue.args = {
 
 export const EmailInput = Template.bind({});
 EmailInput.args = {
-  width: 416,
-  height: 36,
+  $width: 416,
+  $height: 36,
   label: 'Email',
   placeholder: '이메일을 입력해주세요.',
   required: true,
-  validationTester:
-    /^(([^<>()[\]\\.,;:\s@"]+(\.[^<>()[\]\\.,;:\s@"]+)*)|(".+"))@((\[[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}])|(([a-zA-Z\-0-9]+\.)+[a-zA-Z]{2,}))$/,
+  validationTester: /^\w+([.-]?\w+)*@\w+([.-]?\w+)*(\.\w{2,3})+$/,
   errorMsg: '이메일 형식에 맞게 입력해주세요.',
 };

--- a/src/components/shared/TextInput/TextInput.tsx
+++ b/src/components/shared/TextInput/TextInput.tsx
@@ -29,11 +29,7 @@ function TextInput({
 }: TextInputProps) {
   const newId = uuid();
   const [inputValue, setInputValue] = useState(value);
-  const showErrorMsg =
-    errorMsg &&
-    inputValue !== '' &&
-    validationTester &&
-    !validationTester.test(inputValue.trim());
+  const isValid = inputValue === '' || (validationTester && validationTester.test(inputValue.trim()));
 
   return (
     <>
@@ -55,7 +51,7 @@ function TextInput({
         }
         {...props}
       />
-      <ErrorMsg>{showErrorMsg ? errorMsg : ''}</ErrorMsg>
+      <ErrorMsg>{(errorMsg && !isVaild) ? errorMsg : ''}</ErrorMsg>
     </>
   );
 }

--- a/src/components/shared/TextInput/TextInput.tsx
+++ b/src/components/shared/TextInput/TextInput.tsx
@@ -1,49 +1,44 @@
-import { useState, memo } from 'react';
+import { useState, memo, KeyboardEventHandler, ChangeEvent } from 'react';
 import uuid from 'react-uuid';
 import styled from 'styled-components';
+import lengthToPxStr from '@/utils/functions/lengthToPxStr';
+import { widthHeight } from '@/types/style';
 
-export interface TextInputProps {
-  width: number | string;
-  height: number | string;
+export interface TextInputProps extends widthHeight {
   label?: string;
   placeholder?: string;
   required?: boolean;
   validationTester?: RegExp;
   errorMsg?: string;
   value?: string;
-  onKeyDown?: React.KeyboardEventHandler<HTMLInputElement>;
+  onKeyDown?: KeyboardEventHandler<HTMLInputElement>;
   [key: string]: unknown;
 }
 
-const validateTest = (
-  e: React.ChangeEvent<HTMLInputElement>,
-  regex: RegExp
-) => {
-  // TODO: nextElementSibling 대신 다른 좋은 방법은?
-  e.target.nextElementSibling?.classList.toggle(
-    'show',
-    e.target.value !== '' && !regex.test(e.target.value.trim())
-  );
-};
-
 function TextInput({
-  width,
-  height,
+  $width,
+  $height,
   label,
-  placeholder,
-  required,
+  placeholder = '',
+  required = false,
   validationTester,
   errorMsg,
-  value,
+  value = '',
   onKeyDown,
   ...props
 }: TextInputProps) {
   const newId = uuid();
   const [inputValue, setInputValue] = useState(value);
+  const showErrorMsg =
+    errorMsg &&
+    inputValue !== '' &&
+    validationTester &&
+    !validationTester.test(inputValue.trim());
+
   return (
     <>
-      {label && label.trim() && <Label htmlFor={newId}>{label}</Label>}
-      <Input
+      {label?.trim() && <Label htmlFor={newId}>{label}</Label>}
+      <StyledInput
         type="text"
         id={newId}
         name={label}
@@ -52,23 +47,18 @@ function TextInput({
         value={inputValue}
         autoComplete="off"
         autoFocus={true}
-        style={{ width, height }}
+        $width={$width}
+        $height={$height}
         onKeyDown={onKeyDown}
-        onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
-          setInputValue(e.target.value);
-          validationTester && validateTest(e, validationTester);
-        }}
+        onChange={(e: ChangeEvent<HTMLInputElement>) =>
+          setInputValue(e.target.value)
+        }
         {...props}
       />
-      {errorMsg && <ErrorMsg>{errorMsg}</ErrorMsg>}
+      <ErrorMsg>{showErrorMsg ? errorMsg : ''}</ErrorMsg>
     </>
   );
 }
-
-TextInput.defaultProps = {
-  placeholder: '',
-  required: false,
-};
 
 const Label = styled.label`
   display: block;
@@ -77,11 +67,13 @@ const Label = styled.label`
   margin-bottom: 4px;
 `;
 
-const Input = styled.input<TextInputProps>`
+const StyledInput = styled.input<TextInputProps>`
+  width: ${({ $width }) => lengthToPxStr($width)};
+  height: ${({ $height }) => lengthToPxStr($height)};
   padding-left: 10px;
   padding-right: 10px;
   font-size: 14px;
-  line-height: ${({ height }) => height}px;
+  line-height: ${({ $height }) => lengthToPxStr($height)};
   border: 1px solid var(--black);
   border-radius: 4px;
 
@@ -91,15 +83,11 @@ const Input = styled.input<TextInputProps>`
 `;
 
 const ErrorMsg = styled.span`
-  display: none;
-  margin-top: 4px;
-  margin-left: 10px;
-  font-size: 12px;
+  display: block;
+  height: 16px;
+  margin: 4px 10px;
+  font-size: 14px;
   color: var(--red);
-
-  &.show {
-    display: block;
-  }
 `;
 
 export default memo(TextInput);

--- a/src/pages/Item.tsx
+++ b/src/pages/Item.tsx
@@ -86,7 +86,7 @@ function Item() {
               searchResult={searchResult as ProcessedResourceUrlResult}
               size="large"
               hoverInteraction={false}
-            ></LPCover>
+            />
             <AlbumInfo
               searchResult={searchResult as ProcessedResourceUrlResult}
               tracklist={tracklist as ProcessedTracklist}

--- a/src/pages/MyCollection.tsx
+++ b/src/pages/MyCollection.tsx
@@ -117,7 +117,7 @@ function MyCollection() {
         </TitleWrapper>
         <motion.div initial={initial} animate={animate} transition={transition}>
           <VinylItems
-            searchResult={sortItems(
+            searchResults={sortItems(
               result,
               sort as 'title' | 'artist' | 'count' | 'Released' | 'update'
             )}

--- a/src/pages/MyCollections.tsx
+++ b/src/pages/MyCollections.tsx
@@ -114,9 +114,10 @@ function MyCollections() {
         }}
         onClose={() => setDialogType('')}
       >
+        {/* TODO: errorMsg가 표시되는 동안에는 모달 Confirm 불가능하도록 */}
         <TextInput
-          width={416}
-          height={36}
+          $width={416}
+          $height={36}
           label="Collection Name"
           placeholder="생성할 콜렉션의 이름을 입력해주세요."
           required={true}
@@ -142,9 +143,10 @@ function MyCollections() {
         }}
         onClose={() => setDialogType('')}
       >
+        {/* TODO: errorMsg가 표시되는 동안에는 모달 Confirm 불가능하도록 */}
         <TextInput
-          width={416}
-          height={36}
+          $width={416}
+          $height={36}
           label="Collection Name"
           placeholder="수정할 콜렉션의 이름을 입력해주세요."
           required={true}

--- a/src/pages/SearchResult.tsx
+++ b/src/pages/SearchResult.tsx
@@ -158,7 +158,7 @@ function SearchResult() {
             transition={transition}
           >
             <VinylItems
-              searchResult={result}
+              searchResults={result}
               page={'all'}
               view={params.get('view') as ViewProps['view']}
             />

--- a/src/pages/Signin.tsx
+++ b/src/pages/Signin.tsx
@@ -72,12 +72,12 @@ function Signin() {
   return (
     <>
       {checkEmail === 'needAuth' && showAlert && (
-        <Alert type="top">
+        <Alert $type="top">
           인증되지 않은 이메일입니다. 이메일 인증을 완료해주세요.
         </Alert>
       )}
       {checkEmail === 'notExist' && showAlert && (
-        <Alert type="top">이메일 혹은 비밀번호가 일치하지 않습니다.</Alert>
+        <Alert $type="top">이메일 혹은 비밀번호가 일치하지 않습니다.</Alert>
       )}
       <motion.div initial={initial} animate={animate} transition={transition}>
         <FormContainer>

--- a/src/pages/Signup.tsx
+++ b/src/pages/Signup.tsx
@@ -49,10 +49,10 @@ function Signup() {
   return (
     <>
       {checkEmail === 'duplicate' && showAlert && (
-        <Alert type="top">이미 등록된 이메일입니다.</Alert>
+        <Alert $type="top">이미 등록된 이메일입니다.</Alert>
       )}
       {checkEmail !== 'duplicate' && checkEmail !== '' && showAlert && (
-        <Alert type="top">
+        <Alert $type="top">
           인증 메일이 발송되었습니다. 이메일 인증을 완료해주세요.
         </Alert>
       )}

--- a/src/styles/normalizeStyle.ts
+++ b/src/styles/normalizeStyle.ts
@@ -48,7 +48,7 @@ export const NormalizeStyle = createGlobalStyle/*css*/ `
     border-collapse: collapse;
     border-spacing: 0;
   }
-  * {
+  *, *::before, *::after {
     box-sizing: border-box;
   }
   body {

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -162,7 +162,7 @@ export interface ProcessedResult {
     infoContent: string | string[];
     isValid: boolean;
   }[];
-  imgUrl: string;
+  imgUrl: string | undefined;
   resourceUrl: string;
 }
 

--- a/src/types/style.d.ts
+++ b/src/types/style.d.ts
@@ -1,4 +1,4 @@
 export interface widthHeight {
-  width: number | string;
-  height: number | string;
+  $width: number | string;
+  $height: number | string;
 }

--- a/src/utils/functions/lengthToPxStr.ts
+++ b/src/utils/functions/lengthToPxStr.ts
@@ -1,0 +1,4 @@
+const lengthToPxStr = (length: number | string) =>
+  typeof length === 'number' ? length + 'px' : length;
+
+export default lengthToPxStr;

--- a/src/utils/functions/processResult.ts
+++ b/src/utils/functions/processResult.ts
@@ -108,7 +108,7 @@ const processReleaseResult = ({
   }));
   const released = _released === undefined ? '' : _released;
   const year = released === '' ? _year ?? '' : released;
-  // console.log(artist, imgUrl, labels, tracklist, released, year);
+  
   return {
     id: getId(resourceUrl),
     titleInfo: { title, artist },
@@ -163,7 +163,7 @@ const commonRelease = ({
   const imgUrl = images && images[0].resource_url;
   const released = _released === undefined ? '' : _released;
   const year = released === '' ? _year ?? '' : released;
-  // console.log(artist, imgUrl, released, year);
+
   return {
     id: getId(resource_url),
     title,
@@ -199,7 +199,7 @@ const processMasterResult = ({
     title,
     duration,
   }));
-  // console.log(country, artist, imgUrl, year, labels, tracklist);
+
   return {
     id: getId(resourceUrl),
     titleInfo: { title, artist },

--- a/src/utils/functions/processResult.ts
+++ b/src/utils/functions/processResult.ts
@@ -98,7 +98,7 @@ const processReleaseResult = ({
   tracklist: _tracklist,
 }: ReleaseRawResult): ProcessedResourceUrlResult => {
   const artist = artists[0].name;
-  const imgUrl = images[0].resource_url;
+  const imgUrl = images && images[0].resource_url;
   const labels = _labels.map(({ name }) => name);
   const tracklist = _tracklist.map(({ position, type_, title, duration }) => ({
     position,
@@ -108,6 +108,7 @@ const processReleaseResult = ({
   }));
   const released = _released === undefined ? '' : _released;
   const year = released === '' ? _year ?? '' : released;
+  console.log(artist, imgUrl, labels, tracklist, released, year);
   return {
     id: getId(resourceUrl),
     titleInfo: { title, artist },
@@ -159,10 +160,10 @@ const commonRelease = ({
   released: _released,
 }: ReleaseRawResult): RawCommonVinyl => {
   const artist = artists[0].name;
-  const imgUrl = images[0].resource_url;
+  const imgUrl = images && images[0].resource_url;
   const released = _released === undefined ? '' : _released;
   const year = released === '' ? _year ?? '' : released;
-
+  console.log(artist, imgUrl, released, year);
   return {
     id: getId(resource_url),
     title,
@@ -189,7 +190,7 @@ const processMasterResult = ({
 }: MasterRawResult): ProcessedResourceUrlResult => {
   const country = _country ?? '';
   const artist = artists[0].name;
-  const imgUrl = images[0].resource_url;
+  const imgUrl = images && images[0].resource_url;
   const year = _year ?? '';
   const labels = _labels?.map(({ name }) => name) ?? [];
   const tracklist = _tracklist.map(({ position, type_, title, duration }) => ({
@@ -198,6 +199,7 @@ const processMasterResult = ({
     title,
     duration,
   }));
+  console.log(country, artist, imgUrl, year, labels, tracklist);
   return {
     id: getId(resourceUrl),
     titleInfo: { title, artist },
@@ -250,7 +252,6 @@ const commonMaster = ({
   const artist = artists[0].name;
   const imgUrl = images[0].resource_url;
   const year = _year ?? '';
-
   return {
     id: getId(resource_url),
     title,

--- a/src/utils/functions/processResult.ts
+++ b/src/utils/functions/processResult.ts
@@ -108,7 +108,7 @@ const processReleaseResult = ({
   }));
   const released = _released === undefined ? '' : _released;
   const year = released === '' ? _year ?? '' : released;
-  console.log(artist, imgUrl, labels, tracklist, released, year);
+  // console.log(artist, imgUrl, labels, tracklist, released, year);
   return {
     id: getId(resourceUrl),
     titleInfo: { title, artist },
@@ -163,7 +163,7 @@ const commonRelease = ({
   const imgUrl = images && images[0].resource_url;
   const released = _released === undefined ? '' : _released;
   const year = released === '' ? _year ?? '' : released;
-  console.log(artist, imgUrl, released, year);
+  // console.log(artist, imgUrl, released, year);
   return {
     id: getId(resource_url),
     title,
@@ -199,7 +199,7 @@ const processMasterResult = ({
     title,
     duration,
   }));
-  console.log(country, artist, imgUrl, year, labels, tracklist);
+  // console.log(country, artist, imgUrl, year, labels, tracklist);
   return {
     id: getId(resourceUrl),
     titleInfo: { title, artist },

--- a/src/utils/functions/widthHeightToPx.ts
+++ b/src/utils/functions/widthHeightToPx.ts
@@ -1,6 +1,6 @@
-import { widthHeight } from '@/types/style';
+// import { widthHeight } from '@/types/style';
 
-const widthHeightToPx = (widthHeight: widthHeight) =>
+const widthHeightToPx = (widthHeight: number | string) =>
   typeof widthHeight === 'number' ? widthHeight + 'px' : widthHeight;
 
 export default widthHeightToPx;

--- a/src/utils/functions/widthHeightToPx.ts
+++ b/src/utils/functions/widthHeightToPx.ts
@@ -1,6 +1,0 @@
-// import { widthHeight } from '@/types/style';
-
-const widthHeightToPx = (widthHeight: number | string) =>
-  typeof widthHeight === 'number' ? widthHeight + 'px' : widthHeight;
-
-export default widthHeightToPx;

--- a/src/utils/mocks/mockInfo.ts
+++ b/src/utils/mocks/mockInfo.ts
@@ -88,7 +88,7 @@ const mockSearchResult_ellipsis = {
 };
 
 const mockSearchResults = Array.from({ length: 10 }).fill(
-  mockDetailInfo_default
+  mockSearchResult_default
 );
 
 const mockUsersData = [


### PR DESCRIPTION
## PR Type
- [ ] FEAT: 새로운 기능 구현
- [x] FIX: 버그 수정
- [ ] DOCS: 문서 추가 및 수정
- [ ] STYLE: 포맷팅 변경
- [x] REFACTOR: 코드 리팩토링
- [x] TEST: 테스트 관련
- [ ] DEPLOY: 배포 관련
- [ ] CHORE: 빌드, 환경 설정 등 기타 작업

## Abstracts
* Alert, PageTitle, TextInput, LPCover, SearchResultText, VinylItem, VinylItems 컴포넌트 리팩토링

## Description
[공통]
- 노션의 리팩토링 체크리스트 문서를 기반으로 컴포넌트 리팩토링
- 리팩토링 내용 storybook에 반영
- 리팩토링 내용 해당 컴포넌트를 가져다 쓰는 곳에 반영

[유틸함수]
- widthHeightToPx 유틸 함수명을 lengthToPxStr으로 변경

[mockData]
- mockSearchResults 수정

[TextInput 컴포넌트]
- errorMsg가 없다가 보여질 때 TextInput 컴포넌트 아래의 요소들이 errorMsg의 높이만큼 아래로 밀려서 레이아웃이 달라지는 것이 UX 관점에서 좋지 않다고 판단 -> errorMsg가 보여지든 보여지지 않든 높이를 고정시킴
- errorMsg 표시여부 결정 방법을 class toggle 대신 선언적으로 변경

[LPCover 컴포넌트]
- img 요소 드래그 불가능하도록 변경
- 컴포넌트의 width, height를 정사각형으로 고정하되, 저작권 문제를 방지하기 위해 이미지 비율은 고정
- imgUrl이 undefined일 때의 처리를 위해 imgUrl의 default 값을 빈 문자열로 설정

[SearchResultText 컴포넌트]
- ellipsis CSS 대신 JavaScript로 처리
- 검색어가 없거나 빈 문자열일 경우 전체 LP 개수 표시

[VinylItem 컴포넌트]
- 가벼운 계산, 원시값에 사용된 불필요한 useMemo 삭제
- key에 uuid 대신 고유한 id값 사용

## Discussion
* 🚨 리팩토링을 하면서 수정된 부분이 많으니 꼼꼼한 코드리뷰 부탁드립니다!
* 🚨 다른 사람이 구현한 컴포넌트를 리팩토링 하다 보니 의도를 오해하여 잘못 수정한 부분이 있을 수 도 있습니다. 꼼꼼히 확인 부탁드려요!

* LPCover 컴포넌트는 Items 페이지에서는 Link로 작동하면 안될 것 같은데, Link로 작동할지 여부를 결정하는 prop이 추가로 필요?
* SearchResultText 컴포넌트에서 검색어가 빈 문자열일 경우 전체 LP 개수를 출력하도록 수정해 두었으나, 빈 문자열로 검색을 할 경우 허수 검색 결과가 많아 아예 다른 뷰를 보여주어야 할 것 같음(추천 LP?)
* ToggleInputButton에서 ErrorMsg가 보이는 경우(입력값이 유효하지 않은 경우)에는 Enter 입력 or 확인 버튼 클릭시에도 입력값 제출이 안되도록 막아야 함
* AlbumInfo 컴포넌트와, 해당 컴포넌트를 가져다 사용하는 컴포넌트들이 storyBook에서 제대로 표시되지 않는 에러가 있음(새로고침을 할 경우 제대로 표시되나, 왼쪽 탭에서 다른 옵션을 선택할 경우 표시되지 않음) -> AlbumInfo 컴포넌트에서 헤결 필요
* 반응형 처리를 위한 min&max width 처리는 각 컴포넌트가 아닌 main 컴포넌트에서 일괄 처리 필요 -> 나중에 모든 컴포넌트 리팩토링 후에 한번에 작업하면 좋을듯?

* key에 uuid를 사용하는 부분들 모두 id로 대체해야 함
* transform이 필요한 요소에서 left, top, translate 등의 속성 대신 translate3d 사용해야 함
* 가벼운 계산, 원시값에는 useMemo 사용하지 않아야 함

---
resolves #190 
