### PR TITLE
NoSearchWord 컴포넌트 구현

### DIFF
--- a/src/components/features/NoSearchWord/NoSearchWord.stories.tsx
+++ b/src/components/features/NoSearchWord/NoSearchWord.stories.tsx
@@ -1,0 +1,22 @@
+import type { ComponentMeta, ComponentStory } from '@storybook/react';
+import NoSearchWord from './NoSearchWord';
+
+export default {
+  title: 'features/NoSearchWord',
+  component: NoSearchWord,
+  parameters: {
+    docs: {
+      description: {
+        component:
+          '사용자가 검색어를 입력하지 않은 경우 렌더링할 컴포넌트입니다.',
+      },
+    },
+    design: {
+      url: 'https://www.figma.com/file/y5dq4m439YJKRTrKw5ZsZV/33-1%2F3?node-id=2149-1373&t=JXB0sRNf3ItkpRo1-4',
+    },
+  },
+} as ComponentMeta<typeof NoSearchWord>;
+
+const Template: ComponentStory<typeof NoSearchWord> = () => <NoSearchWord />;
+
+export const Example = Template.bind({});

--- a/src/components/features/NoSearchWord/NoSearchWord.tsx
+++ b/src/components/features/NoSearchWord/NoSearchWord.tsx
@@ -1,0 +1,85 @@
+import { useState, useEffect } from 'react';
+import axios from 'axios';
+import { LoadingSpinner, VinylItems } from '@/components';
+import styled from 'styled-components';
+import { processSearchResult } from '@/utils/functions/processResult';
+import { ProcessedResult } from '@/types/data';
+
+const SECRET = import.meta.env.VITE_API_SECRET;
+const KEY = import.meta.env.VITE_API_KEY;
+
+const LP_RECOMMENDATION_URL = Object.freeze({
+  chaerin: `https://api.discogs.com/database/search?&q="꽃갈피"&key=${KEY}&secret=${SECRET}&format=vinyl`,
+  hyunjung: `https://api.discogs.com/database/search?&q="To Let A Good Thing Die"&key=${KEY}&secret=${SECRET}&format=vinyl`,
+  minseok: `https://api.discogs.com/database/search?&q="every letter i sent you"&key=${KEY}&secret=${SECRET}&format=vinyl`,
+  younha: `https://api.discogs.com/database/search?&q="연어 Vol. 3"&key=${KEY}&secret=${SECRET}&format=vinyl`,
+});
+
+function NoSearchWord() {
+  const [result, setResult] = useState<ProcessedResult[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+
+  useEffect(() => {
+    const fetchResults = async () => {
+      setIsLoading(true);
+
+      try {
+        const [res_chaerin, res_hyunjung, res_minseok, res_younha] =
+          await Promise.all([
+            axios.get(LP_RECOMMENDATION_URL.chaerin),
+            axios.get(LP_RECOMMENDATION_URL.hyunjung),
+            axios.get(LP_RECOMMENDATION_URL.minseok),
+            axios.get(LP_RECOMMENDATION_URL.younha),
+          ]);
+
+        setIsLoading(false);
+        setResult(
+          processSearchResult([
+            res_chaerin.data.results[0],
+            res_hyunjung.data.results[0],
+            res_minseok.data.results[0],
+            res_younha.data.results[0],
+          ])
+        );
+      } catch (error) {
+        console.error(error);
+      }
+    };
+    fetchResults();
+  }, []);
+
+  return (
+    <>
+      <NoSearchWordGuideText>{`검색어를 입력하지 않았어요 : (`}</NoSearchWordGuideText>
+      <RecommendationGuideText>
+        33.3 개발자들이 추천하는 LP는 어떠세요?
+      </RecommendationGuideText>
+      {isLoading ? (
+        <StyledLoadingSpinner isLastPage={false} height="100px" />
+      ) : (
+        <VinylItems searchResults={result} page="all" view="block" />
+      )}
+    </>
+  );
+}
+
+const NoSearchWordGuideText = styled.p`
+  min-width: 680px;
+  margin-top: 64px;
+  text-align: center;
+  font-size: 24px;
+  font-weight: 700;
+`;
+
+const RecommendationGuideText = styled.p`
+  min-width: 680px;
+  margin-top: var(--space-md);
+  text-align: center;
+  font-size: var(--text-md);
+`;
+
+const StyledLoadingSpinner = styled(LoadingSpinner)`
+  margin-top: 60px;
+`;
+
+export default NoSearchWord;

--- a/src/components/features/SearchResultText/SearchResultText.tsx
+++ b/src/components/features/SearchResultText/SearchResultText.tsx
@@ -11,23 +11,21 @@ function SearchResultText({ resultCount, searchWord }: SearchResultTextProps) {
   const [searchParams] = useSearchParams();
   const queryString = searchWord || searchParams.get('query') || '';
   const formattedQueryString =
-    '"' + (queryString.length > 20 ? queryString.substring(0, 20) + '… ' : queryString) + '"';
+    '"' +
+    (queryString.length > 20
+      ? queryString.substring(0, 20) + '… '
+      : queryString) +
+    '"';
 
   return useMemo(
     () => (
       <SearchResultTextWrapper>
-        {/* TODO: 임시방편으로 이렇게 구현해두긴 했지만..
-        빈 문자열이 검색되었을 경우 허수 검색결과가 많아서 아예 다른 뷰를 보여주는 게 나을듯.. */}
-        {queryString ? (
-          <>
-            <PurpleText>{formattedQueryString}</PurpleText>
-            <NormalText>
-              &nbsp;&nbsp;검색 결과&nbsp;&nbsp;{resultCount} 건
-            </NormalText>
-          </>
-        ) : (
-          <NormalText>전체 LP&nbsp;&nbsp;{resultCount} 건</NormalText>
-        )}
+        <>
+          <PurpleText>{formattedQueryString}</PurpleText>
+          <NormalText>
+            &nbsp;&nbsp;검색 결과&nbsp;&nbsp;{resultCount} 건
+          </NormalText>
+        </>
       </SearchResultTextWrapper>
     ),
     [resultCount, queryString]

--- a/src/components/features/index.ts
+++ b/src/components/features/index.ts
@@ -14,6 +14,7 @@ import TitleInfo from './TitleInfo/TitleInfo';
 import VinylItem from './VinylItem/VinylItem';
 import VinylItems from './VinylItems/VinylItems';
 import WritableInfo from './WritableInfo/WritableInfo';
+import NoSearchWord from './NoSearchWord/NoSearchWord';
 
 export {
   AddCollectionButton,
@@ -32,4 +33,5 @@ export {
   VinylItem,
   VinylItems,
   WritableInfo,
+  NoSearchWord,
 };

--- a/src/components/shared/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/components/shared/LoadingSpinner/LoadingSpinner.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export interface LoadingSpinnerProps extends SpinnerProps {
-  height?: string | number;
+  height?: string;
 }
 
 export interface SpinnerProps {

--- a/src/components/shared/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/components/shared/LoadingSpinner/LoadingSpinner.tsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 
 export interface LoadingSpinnerProps extends SpinnerProps {
-  height: string | number;
+  height?: string | number;
 }
 
 export interface SpinnerProps {

--- a/src/components/shared/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/components/shared/LoadingSpinner/LoadingSpinner.tsx
@@ -8,8 +8,14 @@ export interface SpinnerProps {
   isLastPage: boolean;
 }
 
-function LoadingSpinner({ isLastPage, height }: LoadingSpinnerProps) {
-  return <Spinner isLastPage={isLastPage} style={{ width: '100vw', height }} />;
+function LoadingSpinner({ isLastPage, height, ...props }: LoadingSpinnerProps) {
+  return (
+    <Spinner
+      isLastPage={isLastPage}
+      style={{ width: '100vw', height }}
+      {...props}
+    />
+  );
 }
 
 LoadingSpinner.defaultProps = {

--- a/src/components/shared/LoadingSpinner/LoadingSpinner.tsx
+++ b/src/components/shared/LoadingSpinner/LoadingSpinner.tsx
@@ -8,7 +8,11 @@ export interface SpinnerProps {
   isLastPage: boolean;
 }
 
-function LoadingSpinner({ isLastPage, height, ...props }: LoadingSpinnerProps) {
+function LoadingSpinner({
+  isLastPage,
+  height = '50px',
+  ...props
+}: LoadingSpinnerProps) {
   return (
     <Spinner
       isLastPage={isLastPage}
@@ -17,10 +21,6 @@ function LoadingSpinner({ isLastPage, height, ...props }: LoadingSpinnerProps) {
     />
   );
 }
-
-LoadingSpinner.defaultProps = {
-  height: '50px',
-};
 
 const Spinner = styled.div<SpinnerProps>`
   display: ${({ isLastPage }) => (isLastPage ? 'none' : 'block')};

--- a/src/components/shared/TextInput/TextInput.tsx
+++ b/src/components/shared/TextInput/TextInput.tsx
@@ -29,7 +29,9 @@ function TextInput({
 }: TextInputProps) {
   const newId = uuid();
   const [inputValue, setInputValue] = useState(value);
-  const isValid = inputValue === '' || (validationTester && validationTester.test(inputValue.trim()));
+  const isValid =
+    inputValue === '' ||
+    (validationTester && validationTester.test(inputValue.trim()));
 
   return (
     <>
@@ -51,7 +53,7 @@ function TextInput({
         }
         {...props}
       />
-      <ErrorMsg>{(errorMsg && !isVaild) ? errorMsg : ''}</ErrorMsg>
+      <ErrorMsg>{errorMsg && !isValid ? errorMsg : ''}</ErrorMsg>
     </>
   );
 }

--- a/src/pages/SearchResult.tsx
+++ b/src/pages/SearchResult.tsx
@@ -19,6 +19,7 @@ import {
   InquiryButton,
   NewDialog,
   SelectCollectionForm,
+  NoSearchWord,
 } from '@/components';
 import styled from 'styled-components';
 import { motion } from 'framer-motion';
@@ -77,17 +78,19 @@ function SearchResult() {
   useEffect(() => setDialogType(''), []);
 
   useEffect(() => {
-    const observer = new IntersectionObserver(([entry]) => {
-      if (pageNum === totalPageNum) return;
+    if (value) {
+      const observer = new IntersectionObserver(([entry]) => {
+        if (pageNum === totalPageNum) return;
 
-      if (entry.isIntersecting) {
-        setPageNum((pageNum) => (pageNum += 1));
-      }
-    }, options);
+        if (entry.isIntersecting) {
+          setPageNum((pageNum) => (pageNum += 1));
+        }
+      }, options);
 
-    observer.observe(observerTarget?.current as HTMLDivElement);
+      observer.observe(observerTarget?.current as HTMLDivElement);
 
-    return () => observer.disconnect();
+      return () => observer.disconnect();
+    }
   }, [result]);
 
   useEffect(() => {
@@ -142,38 +145,44 @@ function SearchResult() {
         <Header />
         <Main>
           <h1 className="srOnly">Search Result</h1>
-          <SearchResultWrapper>
-            <SearchResultText resultCount={itemCount} />
-            {/* <Dropdown
+          {value ? (
+            <>
+              <SearchResultWrapper>
+                <SearchResultText resultCount={itemCount} />
+                {/* <Dropdown
               dropKind="sort"
               label={SORT_LABEL}
               content={SORT_CONTENT}
             /> */}
-            <Dropdown
-              dropKind="view"
-              label={VIEW_LABEL}
-              content={VIEW_CONTENT}
-            />
-          </SearchResultWrapper>
-          <motion.div
-            initial={initial}
-            animate={animate}
-            transition={transition}
-          >
-            <VinylItems
-              searchResults={result}
-              page={'all'}
-              view={params.get('view') as ViewProps['view']}
-            />
-          </motion.div>
-          <div
-            ref={observerTarget}
-            style={{
-              width: '100vw',
-              height: '40px',
-            }}
-          />
-          <LoadingSpinner isLastPage={pageNum === totalPageNum} />
+                <Dropdown
+                  dropKind="view"
+                  label={VIEW_LABEL}
+                  content={VIEW_CONTENT}
+                />
+              </SearchResultWrapper>
+              <motion.div
+                initial={initial}
+                animate={animate}
+                transition={transition}
+              >
+                <VinylItems
+                  searchResults={result}
+                  page={'all'}
+                  view={params.get('view') as ViewProps['view']}
+                />
+              </motion.div>
+              <div
+                ref={observerTarget}
+                style={{
+                  width: '100vw',
+                  height: '40px',
+                }}
+              />
+              <LoadingSpinner isLastPage={pageNum === totalPageNum} />
+            </>
+          ) : (
+            <NoSearchWord />
+          )}
           <InquiryButton />
           <GoToTopButton />
         </Main>


### PR DESCRIPTION
## PR Type
- [x] FEAT: 새로운 기능 구현
- [x] FIX: 버그 수정
- [ ] DOCS: 문서 추가 및 수정
- [ ] STYLE: 포맷팅 변경
- [x] REFACTOR: 코드 리팩토링
- [x] TEST: 테스트 관련
- [ ] DEPLOY: 배포 관련
- [ ] CHORE: 빌드, 환경 설정 등 기타 작업

## Abstracts
* 사용자가 검색어를 입력하지 않은 경우 렌더링할 NoSearchWord 컴포넌트를 구현합니다.

## Description
### 작업 내용
- NoSearchWord 컴포넌트 구현 및 연관된 컴포넌트에 적용
- NoSearchWord 컴포넌트의 StoryBook 작성

### 컴포넌트 구조
```
<>
  <NoSearchWordGuideText />
  <RecommendationGuideText />
  <VinylItems />
</>
```

### 구현 이미지
![image](https://user-images.githubusercontent.com/101828759/228018422-c22f7491-4cf3-4c6e-86ac-a88faef279b2.png)


## Discussion
* 추천 LP fetch 요청 방식 변경에 대한 논의를 추후 해보면 좋을 듯합니다!

---
Close #194 
