### PR TITLE
썸네일 이미지로 변경 및 빈 데이터 렌더링 방지 

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,15 +33,38 @@
       })(window, document, 'script', 'dataLayer', 'GTM-WKGGTPX');
     </script>
     <!-- End Google Tag Manager -->
+
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <meta property="og:title" content="33-1-3-Record your Records!" />
-    <meta property="og:type" content="website" />
+
+    <!-- 사이트 이름 -->
+    <meta property="og:site_name" content="음반 아카이빙 서비스, 33.3" />
+
+    <!-- 사이트 대표 url -->
     <meta property="og:url" content="https://33-1-3.com/" />
-    <meta property="og:image:width" content="500" />
-    <meta property="og:image:height" content="300" />
+    <meta property="twitter:url" content="https://33-1-3.com/" />
+
+    <!-- 게시글 제목 -->
+    <meta property="og:title" content="33-1-3-Record your Records!" />
+    <meta name="twitter:title" content="33-1-3-Record your Records!" />
+
+    <!-- 게시글 설명 -->
+    <meta property="og:description" content="당신의 음반을 정리해보세요!" />
+    <meta name="twitter:description" content="당신의 음반을 정리해보세요!" />
+
+    <meta property="og:type" content="website" />
+    <meta name="twitter:card" content="summary" />
+
+    <!-- 썸네일 이미지 -->
     <meta property="og:image" content="https://33-1-3.com/assets/logo.svg" />
-    <meta property="og:description" content="당쉰의 바이닐을 정리해보세요!" />
+    <meta name="twitter:image" content="https://33-1-3.com/assets/logo.svg" />
+
+    <meta property="og:image:width" content="500" />
+    <meta name="twitter:image:width" content="500" />
+
+    <meta property="og:image:height" content="300" />
+    <meta name="twitter:image:height" content="300" />
+
     <title>33-1-3</title>
   </head>
   <body>

--- a/src/components/features/VinylItems/VinylItems.tsx
+++ b/src/components/features/VinylItems/VinylItems.tsx
@@ -15,8 +15,14 @@ function VinylItems({ searchResults, page, view, ...props }: VinylItemsProps) {
   return (
     <VinylItemsWrapper view={view} {...props}>
       {searchResults.map((result) => {
+        const {
+          titleInfo: { title, artist },
+        } = result;
+        const isEmpty = title === '' || artist === '';
         const releasedId = getId(result.resourceUrl);
-        return (
+        return isEmpty ? (
+          <></>
+        ) : (
           <VinylItem
             key={releasedId}
             searchResult={result}

--- a/src/components/shared/TextInput/TextInput.tsx
+++ b/src/components/shared/TextInput/TextInput.tsx
@@ -29,7 +29,9 @@ function TextInput({
 }: TextInputProps) {
   const newId = uuid();
   const [inputValue, setInputValue] = useState(value);
-  const isValid = inputValue === '' || (validationTester && validationTester.test(inputValue.trim()));
+  const isValid =
+    inputValue === '' ||
+    (validationTester && validationTester.test(inputValue.trim()));
 
   return (
     <>
@@ -51,7 +53,7 @@ function TextInput({
         }
         {...props}
       />
-      <ErrorMsg>{(errorMsg && !isVaild) ? errorMsg : ''}</ErrorMsg>
+      <ErrorMsg>{errorMsg && !isValid ? errorMsg : ''}</ErrorMsg>
     </>
   );
 }

--- a/src/types/data.d.ts
+++ b/src/types/data.d.ts
@@ -16,9 +16,16 @@ export interface RawResult {
   thumb: string;
   cover_image: string;
   resource_url: string;
-  community: string[];
+  community: {
+    want: number;
+    have: number;
+  };
   format_quantity: number;
-  formats: string[];
+  formats: {
+    name: string;
+    qty: string;
+    descriptions: string[];
+  }[];
 }
 
 interface ReleaseCompany {

--- a/src/utils/functions/processResult.ts
+++ b/src/utils/functions/processResult.ts
@@ -35,14 +35,18 @@ const processSearchResult = (result: RawResult[]): ProcessedResult[] =>
     ({
       country,
       cover_image,
+      thumb,
       genre,
       label,
+      master_url,
       resource_url,
       style,
       title,
       year,
     }: RawResult) => {
       const [artist, albumTitle] = title.split(' - ');
+      // console.log('master', master_url);
+      // console.log('resource', resource_url);
 
       return {
         id: getId(resource_url),
@@ -58,29 +62,29 @@ const processSearchResult = (result: RawResult[]): ProcessedResult[] =>
             infoContent: genre,
             isValid: validator(genre),
           },
-          {
-            infoName: 'Style',
-            infoContent: style,
-            isValid: validator(style),
-          },
-          {
-            infoName: 'Country',
-            infoContent: country,
-            isValid: validator(country),
-          },
-          {
-            infoName: 'Label',
-            infoContent: label,
-            isValid: validator(label),
-          },
+          // {
+          //   infoName: 'Style',
+          //   infoContent: style,
+          //   isValid: validator(style),
+          // },
+          // {
+          //   infoName: 'Country',
+          //   infoContent: country,
+          //   isValid: validator(country),
+          // },
+          // {
+          //   infoName: 'Label',
+          //   infoContent: label,
+          //   isValid: validator(label),
+          // },
         ],
-        imgUrl: cover_image,
+        imgUrl: thumb,
         resourceUrl: resource_url,
       };
     }
   );
 
-const tracklistVaildator = (tracklist: RawTracklist[]) =>
+const tracklistValidator = (tracklist: RawTracklist[]) =>
   tracklist.length !== 0 && Array.isArray(tracklist);
 
 // Release API 결과 처리
@@ -108,7 +112,7 @@ const processReleaseResult = ({
   }));
   const released = _released === undefined ? '' : _released;
   const year = released === '' ? _year ?? '' : released;
-  
+
   return {
     id: getId(resourceUrl),
     titleInfo: { title, artist },
@@ -144,7 +148,7 @@ const processReleaseResult = ({
     tracklist: {
       infoName: 'Tracklist',
       infoContent: tracklist,
-      isValid: tracklistVaildator(tracklist),
+      isValid: tracklistValidator(tracklist),
     },
   };
 };
@@ -191,7 +195,7 @@ const processMasterResult = ({
   const country = _country ?? '';
   const artist = artists[0].name;
   const imgUrl = images && images[0].resource_url;
-  const year = _year ?? '';
+  const year = (_year ?? '') + '';
   const labels = _labels?.map(({ name }) => name) ?? [];
   const tracklist = _tracklist.map(({ position, type_, title, duration }) => ({
     position,
@@ -235,7 +239,7 @@ const processMasterResult = ({
     tracklist: {
       infoName: 'Tracklist',
       infoContent: tracklist,
-      isValid: tracklistVaildator(tracklist),
+      isValid: tracklistValidator(tracklist),
     },
   };
 };

--- a/src/utils/functions/tracklistValidator.ts
+++ b/src/utils/functions/tracklistValidator.ts
@@ -1,6 +1,0 @@
-import { RawTracklist } from '@/types/data';
-
-const tracklistVaildator = (tracklist: RawTracklist[]) =>
-  tracklist.length !== 0 && Array.isArray(tracklist);
-
-export default tracklistVaildator;


### PR DESCRIPTION
## PR Type
- [x] FEAT: 새로운 기능 구현
- [x] FIX: 버그 수정
- [ ] DOCS: 문서 추가 및 수정
- [ ] STYLE: 포맷팅 변경
- [ ] REFACTOR: 코드 리팩토링
- [ ] TEST: 테스트 관련
- [ ] DEPLOY: 배포 관련
- [ ] CHORE: 빌드, 환경 설정 등 기타 작업

## Abstracts
Discogs API의 변경된 제한으로 인해 생긴 이미지 요청 초과 문제 처리했습니다. 
Search API의 응답이 비어있는 경우 처리했습니다. 

## Description
- 이미지 요청 초과 문제는 썸네일 이미지로 변경하여 해결했습니다. 
- API 응답에서 타이틀이나 아티스트가 빈 문자열인 경우 렌더링하지 않도록 했습니다. 
- 추가적으로 twitter card를 위한 메타 태그 추가했습니다. 

## Discussion
1. 현재 VinylItems 컴포넌트에서 VInylItem의 key로 releasedId를 부여하는데 중복되는 아이디들이 존재하여 react 오류가 발생합니다.
2. 비어있는 데이터는 렌더링하지 않도록 했으나 미관상 예쁘지 않습니다. 원래 데이터가 한 줄 꽉차게 렌더링되는데 하나라도 렌더링되지 않으면 줄이 비어있어서... 추후 회의에서 이야기해봅시다!!  
---
resolved: #196  

